### PR TITLE
fix: lsp-hover時に枠をつける設定が再起動した際に消えてしまう問題を解消

### DIFF
--- a/.bin/.config/nvim/lua/auto_command.lua
+++ b/.bin/.config/nvim/lua/auto_command.lua
@@ -53,11 +53,6 @@ vim.cmd([[
   autocmd BufWritePost *.lua source <afile> | echo "Configuration reloaded!"
 ]])
 
-vim.lsp.handlers["textDocument/hover"] = vim.lsp.with(vim.lsp.handlers.hover, {
-  -- 枠のスタイルを指定します: single, double, rounded, solid, shadow など
-  border = "rounded",
-})
-
 vim.api.nvim_create_autocmd("CursorMoved", {
   pattern = "*",
   callback = function()

--- a/.bin/.config/nvim/lua/keymaps.lua
+++ b/.bin/.config/nvim/lua/keymaps.lua
@@ -5,8 +5,8 @@ local opts = { noremap = true, silent = true }
 -- Normal mode keymaps
 map("n", "<C-h>", "<C-w>h", opts)
 map("n", "<C-l>", "<C-w>l", opts)
-map("n", "<C-j>", "<C-w>j", opts)
-map("n", "<C-k>", "<C-w>k", opts)
+--map("n", "<C-j>", "<C-w>j", opts)
+--map("n", "<C-k>", "<C-w>k", opts)
 map("n", "<C-b>", ":NvimTreeToggle<CR>", opts)
 
 -- easy-motion
@@ -52,9 +52,7 @@ map("v", "<leader>/", "<Plug>NERDCommenterToggle", opts)
 -- terminal mode
 map("t", "<esc>", [[<C-\><C-n>]], opts)
 
---map('t', '<C-h>', [[<Cmd>wincmd h<CR>]], opts)
 map("t", "<C-j>", [[<Cmd>wincmd j<CR>]], opts)
---map('t', '<C-k>', [[<Cmd>wincmd k<CR>]], opts)
 map("t", "<C-l>", [[<Cmd>wincmd l<CR>]], opts)
 map("t", "<C-w>", [[<C-\><C-n><C-w>]], opts)
 map("t", "<C-t>", "<CMD>ToggleTerm<CR>", opts)

--- a/.bin/.config/nvim/lua/lsp.lua
+++ b/.bin/.config/nvim/lua/lsp.lua
@@ -64,9 +64,18 @@ local function set_lsp_keymaps(bufnr)
   -- Keymaps for LSP
   buf_map("n", "gD", "<cmd>lua vim.lsp.buf.declaration()<CR>")
   buf_map("n", "gd", "<cmd>lua vim.lsp.buf.definition()<CR>")
-  buf_map("n", "K", "<cmd>lua vim.lsp.buf.hover()<CR>")
+  --buf_map("n", "K", "<cmd>lua vim.lsp.buf.hover()<CR>")
   buf_map("n", "gi", "<cmd>lua vim.lsp.buf.implementation()<CR>")
   -- More keymaps can be added here
+end
+
+local on_attach = function(client, bufnr)
+  set_lsp_keymaps(bufnr)
+
+  vim.lsp.handlers["textDocument/hover"] = vim.lsp.with(vim.lsp.handlers.hover, {
+    -- 枠のスタイルを指定します: single, double, rounded, solid, shadow など
+    border = "single",
+  })
 end
 
 -- Function to setup LSP servers with the above keymaps
@@ -76,7 +85,7 @@ local function setup_servers()
       -- 特定のLSPサーバーのカスタム設定を行う
       if server_name == "lua_ls" then
         require("lspconfig")[server_name].setup({
-          on_attach = set_lsp_keymaps,
+          on_attach = on_attach,
           settings = {
             Lua = {
               diagnostics = {
@@ -88,7 +97,7 @@ local function setup_servers()
         })
       else
         require("lspconfig")[server_name].setup({
-          on_attach = set_lsp_keymaps,
+          on_attach = on_attach,
         })
       end
     end,
@@ -105,5 +114,3 @@ require("lspconfig").eslint.setup({
     })
   end,
 })
-
-require("lspconfig.ui.windows").default_options.border = "single"

--- a/.bin/.config/nvim/lua/plugins.lua
+++ b/.bin/.config/nvim/lua/plugins.lua
@@ -165,7 +165,7 @@ require("packer").startup({
               ["cmp.entry.get_documentation"] = true, -- requires hrsh7th/nvim-cmp
             },
             hover = {
-              enable = false,
+              enabled = false,
             },
           },
           -- you can enable a preset for easier configuration


### PR DESCRIPTION
lsp周りの設定はlsp-config時にやる必要があるようだ
今回はmanson-lspconfigにその設定を追記した
このlsに対して同じ設定をする必要がない
またshift+kによるhoverショートカットを消した
#7 