### PR TITLE
prettier format後に謎の差分が出る問題を解消

### DIFF
--- a/.bin/.config/nvim/lua/plugins/lsp.lua
+++ b/.bin/.config/nvim/lua/plugins/lsp.lua
@@ -51,6 +51,14 @@ return {
             })
           end
         end,
+        tsserver = function()
+          require("lspconfig").tsserver.setup({
+            on_attach = function(client, bufnr)
+              client.server_capabilities.documentFormattingProvider = false
+              client.server_capabilities.documentRangeFormattingProvider = false
+            end,
+          })
+        end,
       })
     end,
   },


### PR DESCRIPTION
prettierのformat後に謎の差分が出ていたがtsのlspがformatしていたがの原因だった
 ts lspのformat機能の無効化した
close #16 