### PR TITLE
feat: PHP 7.4のサポートを削除

### DIFF
--- a/conf/.config/nix/home-manager/common.nix
+++ b/conf/.config/nix/home-manager/common.nix
@@ -1,4 +1,4 @@
-{ inputs, lib, config, pkgs, phps, ... }:
+{ inputs, lib, config, pkgs, ... }:
 
 
 let
@@ -58,10 +58,6 @@ in
         };
       }))
       deno
-      # php-pcntlはプロセス制御を行うプラグインでGithub Actions上の環境ではこれのテストが失敗するためphp-pcntlを除外する
-      (phps.packages.${pkgs.system}.php74.withExtensions ({ enabled, all }:
-        builtins.filter (ext: ext.pname != "php-pcntl") enabled
-      ))
       php84Extensions.xdebug
     ];
 

--- a/conf/.config/nix/home-manager/darwin.nix
+++ b/conf/.config/nix/home-manager/darwin.nix
@@ -1,4 +1,4 @@
-{ inputs, lib, config, pkgs, phps, ... }:
+{ inputs, lib, config, pkgs,  ... }:
 
 {
   imports = [

--- a/conf/.config/nix/home-manager/linux.nix
+++ b/conf/.config/nix/home-manager/linux.nix
@@ -1,4 +1,4 @@
-{ inputs, lib, config, pkgs, phps, ... }:
+{ inputs, lib, config, pkgs,  ... }:
 
 {
   imports = [

--- a/flake.lock
+++ b/flake.lock
@@ -1,21 +1,5 @@
 {
   "nodes": {
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1767039857,
-        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
-        "owner": "NixOS",
-        "repo": "flake-compat",
-        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
@@ -131,68 +115,12 @@
         "type": "github"
       }
     },
-    "phps": {
-      "inputs": {
-        "flake-compat": "flake-compat",
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "utils": "utils"
-      },
-      "locked": {
-        "lastModified": 1771130742,
-        "narHash": "sha256-BMGidUCerB3ZsNDVsQjC3/QnWwQ7+Wc0XFOIyvTB1g8=",
-        "owner": "fossar",
-        "repo": "nix-phps",
-        "rev": "c0b483e4b9940fd4120811ffb77ffb3d7561f762",
-        "type": "github"
-      },
-      "original": {
-        "owner": "fossar",
-        "repo": "nix-phps",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "home-manager": "home-manager",
         "neovim-nightly-overlay": "neovim-nightly-overlay",
         "nix-darwin": "nix-darwin",
-        "nixpkgs": "nixpkgs",
-        "phps": "phps"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -11,12 +11,6 @@
       url = "github:LnL7/nix-darwin";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    # PHP 7.4などのレガシーPHPバージョンのリポジトリを追加
-    phps = {
-      url = "github:fossar/nix-phps";
-      # nixpkgsを共有して一貫性を保つ
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
     neovim-nightly-overlay = {
       url = "github:nix-community/neovim-nightly-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -34,7 +28,7 @@
     ];
   };
 
-  outputs = { self, nixpkgs, home-manager, nix-darwin, phps, neovim-nightly-overlay } @ inputs:
+  outputs = { self, nixpkgs, home-manager, nix-darwin, neovim-nightly-overlay } @ inputs:
     let
       system = {
         darwin = "aarch64-darwin";
@@ -86,8 +80,6 @@
           };
           extraSpecialArgs = {
             inherit inputs;
-            # phpsパッケージを渡す
-            inherit phps;
           };
           modules = [
             ./conf/.config/nix/home-manager/darwin.nix
@@ -101,7 +93,6 @@
           };
           extraSpecialArgs = {
             inherit inputs;
-            inherit phps;
           };
           modules = [
             ./conf/.config/nix/home-manager/linux.nix


### PR DESCRIPTION
PHP7.4をNix経由で入れるのをやめる
ローカルでphp7.4をほぼ使ってないのとflake.lockを更新した時にbuildエラーになる時が結構ある
ようするにほぼ使ってないのにメンテナンスするのがめんどくさいので削除

https://github.com/happy663/dotfiles/actions/runs/22404572660/job/64860553240?pr=199
