### PR TITLE
feat(nvim): claude-input に hide/show 機能を追加

### DIFF
--- a/conf/.config/nvim/lua/ai.lua
+++ b/conf/.config/nvim/lua/ai.lua
@@ -21,13 +21,12 @@ end, { nargs = "*" })
 
 local claude_input_ok, claude_input = pcall(require, "claude_input")
 if claude_input_ok then
+  claude_input.setup()
+
   vim.api.nvim_create_user_command("ClaudeDraftSend", function()
-    local success, message = claude_input.send_draft()
+    -- send_draft は成功時に内部で clear + hide (default) を行う
+    local success, message = claude_input.send_draft({ hide_after = true })
     if success then
-      local cleared, clear_message = claude_input.clear_draft()
-      if not cleared then
-        vim.notify(clear_message, vim.log.levels.WARN)
-      end
       vim.notify(message, vim.log.levels.INFO)
     else
       vim.notify(message, vim.log.levels.ERROR)
@@ -74,46 +73,35 @@ if claude_input_ok then
     return nil
   end
 
-  local function move_to_best_previous_window(excluded_winid)
-    local prev_winid = vim.t.claude_input_prev_winid
-    if prev_winid and vim.api.nvim_win_is_valid(prev_winid) and prev_winid ~= excluded_winid then
-      vim.api.nvim_set_current_win(prev_winid)
-      return
-    end
-
-    local windows = vim.api.nvim_tabpage_list_wins(0)
-    for _, winid in ipairs(windows) do
-      if vim.api.nvim_win_is_valid(winid) and winid ~= excluded_winid then
-        vim.api.nvim_set_current_win(winid)
-        return
-      end
-    end
-  end
-
   local function toggle_claude_draft_buffer()
     local current_winid = vim.api.nvim_get_current_win()
     local draft_winid = find_claude_draft_winid()
 
+    -- claude-input 内から押下 → hide（フォーカス復帰は hide() 内部で処理）
     if draft_winid and draft_winid == current_winid then
-      move_to_best_previous_window(draft_winid)
+      claude_input.hide()
       return
     end
 
     vim.t.claude_input_prev_winid = current_winid
 
+    -- 可視ウィンドウがあればそこに focus
     if draft_winid then
       vim.api.nvim_set_current_win(draft_winid)
       vim.cmd("startinsert")
       return
     end
 
+    -- ウィンドウが無い（初回 or hidden）→ target の下に再表示
     local current_bufnr = vim.api.nvim_get_current_buf()
     local focus_opts = {
       draft_height = dual_ai_config.draft_height,
       target_pattern = dual_ai_config.draft_target_pattern,
     }
+    -- terminal から押された場合は current terminal に再リンク
     if vim.bo[current_bufnr].buftype == "terminal" then
       focus_opts.claude_bufnr = current_bufnr
+      vim.t.claude_terminal_bufnr = current_bufnr
     end
 
     local success, message = claude_input.focus_or_open(focus_opts)

--- a/conf/.config/nvim/lua/claude_input.lua
+++ b/conf/.config/nvim/lua/claude_input.lua
@@ -114,6 +114,20 @@ local function open_split_below_target(target_bufnr, target_pattern, draft_heigh
     if type(draft_height) == "number" and draft_height > 0 then
       vim.cmd("resize " .. tostring(draft_height))
     end
+
+    -- split で target terminal window が縮小した時、cursor 位置が visible 領域外になるのを防ぐため最下部へ移動する
+    local draft_winid = vim.api.nvim_get_current_win()
+    if vim.api.nvim_win_is_valid(target_winid) then
+      local term_bufnr = vim.api.nvim_win_get_buf(target_winid)
+      if is_valid_buf(term_bufnr) then
+        local line_count = vim.api.nvim_buf_line_count(term_bufnr)
+        pcall(vim.api.nvim_win_set_cursor, target_winid, { line_count, 0 })
+      end
+    end
+    if vim.api.nvim_win_is_valid(draft_winid) then
+      vim.api.nvim_set_current_win(draft_winid)
+    end
+
     return true
   end
 

--- a/conf/.config/nvim/lua/claude_input.lua
+++ b/conf/.config/nvim/lua/claude_input.lua
@@ -6,6 +6,11 @@ M.defaults = {
   target_pattern = "claude",
 }
 
+-- タブが閉じられた際に、そのタブに紐づく [Claude Input] バッファを wipe するためのレジストリ
+-- key: tabpage handle, value: bufnr
+local tab_bufnr_registry = {}
+local setup_done = false
+
 local function is_valid_buf(bufnr)
   return bufnr ~= nil and vim.api.nvim_buf_is_valid(bufnr)
 end
@@ -58,6 +63,67 @@ local function resolve_target_terminal_bufnr(target_pattern)
   return nil
 end
 
+-- target terminal が現タブで表示されているウィンドウ ID を返す。
+-- 1. target_bufnr が現タブのウィンドウに存在すればその winid
+-- 2. なければ target_pattern で再探索し、そのバッファの winid
+-- 3. それでも見つからなければ nil
+local function resolve_target_terminal_winid(target_bufnr, target_pattern)
+  local current_tab_wins = vim.api.nvim_tabpage_list_wins(0)
+
+  local function find_winid_for(bufnr)
+    if not is_valid_buf(bufnr) then
+      return nil
+    end
+    for _, winid in ipairs(current_tab_wins) do
+      if vim.api.nvim_win_is_valid(winid) and vim.api.nvim_win_get_buf(winid) == bufnr then
+        return winid
+      end
+    end
+    return nil
+  end
+
+  local winid = find_winid_for(target_bufnr)
+  if winid then
+    return winid
+  end
+
+  if type(target_pattern) == "string" and target_pattern ~= "" then
+    local bridge_ok, terminal_bridge = pcall(require, "terminal_bridge")
+    if bridge_ok then
+      local terminal = terminal_bridge.find_terminal_by_pattern(target_pattern, false)
+      if terminal and is_valid_buf(terminal.bufnr) then
+        local pwinid = find_winid_for(terminal.bufnr)
+        if pwinid then
+          return pwinid
+        end
+      end
+    end
+  end
+
+  return nil
+end
+
+-- target terminal のウィンドウの下に horizontal split を作る。
+-- target が見つからない場合は botright split にフォールバックする。
+-- 戻り値: true = target の下に作成、false = フォールバック (botright)
+local function open_split_below_target(target_bufnr, target_pattern, draft_height)
+  local target_winid = resolve_target_terminal_winid(target_bufnr, target_pattern)
+  if target_winid then
+    vim.api.nvim_set_current_win(target_winid)
+    vim.cmd("belowright split")
+    if type(draft_height) == "number" and draft_height > 0 then
+      vim.cmd("resize " .. tostring(draft_height))
+    end
+    return true
+  end
+
+  vim.cmd("botright split")
+  if type(draft_height) == "number" and draft_height > 0 then
+    vim.cmd("resize " .. tostring(draft_height))
+  end
+  return false
+end
+
 local function ensure_buffer_keymaps(bufnr)
   vim.keymap.set("n", "<C-CR>", "<Cmd>ClaudeDraftSend<CR>", {
     buffer = bufnr,
@@ -88,22 +154,31 @@ end
 function M.focus_or_open(opts)
   opts = opts or {}
 
+  local target_pattern = opts.target_pattern or vim.t.claude_input_target_pattern or M.defaults.target_pattern
   local draft_bufnr = get_draft_bufnr()
+
   if draft_bufnr then
     if focus_existing_draft(draft_bufnr) then
       return true, "Focused existing draft buffer"
     end
-    vim.cmd("belowright split")
-    if type(opts.draft_height) == "number" and opts.draft_height > 0 then
-      vim.cmd("resize " .. tostring(opts.draft_height))
+
+    -- バッファは存在するがウィンドウ未表示 → target terminal の下に再表示
+    local target_bufnr = opts.claude_bufnr
+    if not is_valid_buf(target_bufnr) then
+      target_bufnr = vim.t.claude_terminal_bufnr
     end
+
+    local via_target = open_split_below_target(target_bufnr, target_pattern, opts.draft_height)
     vim.api.nvim_win_set_buf(0, draft_bufnr)
     vim.wo.winfixheight = true
     vim.cmd("startinsert")
+    if not via_target then
+      notify("Target terminal window not found; opened draft at bottom", vim.log.levels.WARN)
+    end
     return true, "Opened existing draft buffer"
   end
 
-  local target_pattern = opts.target_pattern or vim.t.claude_input_target_pattern or M.defaults.target_pattern
+  -- 新規作成パス
   local terminal_bufnr = opts.claude_bufnr
   if not is_valid_buf(terminal_bufnr) then
     terminal_bufnr = resolve_target_terminal_bufnr(target_pattern)
@@ -112,14 +187,14 @@ function M.focus_or_open(opts)
     return false, "Target terminal not found for draft buffer"
   end
 
-  vim.cmd("belowright split")
-  if type(opts.draft_height) == "number" and opts.draft_height > 0 then
-    vim.cmd("resize " .. tostring(opts.draft_height))
-  end
+  local via_target = open_split_below_target(terminal_bufnr, target_pattern, opts.draft_height)
   M.open_input_buffer({
     claude_bufnr = terminal_bufnr,
     target_pattern = target_pattern,
   })
+  if not via_target then
+    notify("Target terminal window not found; opened draft at bottom", vim.log.levels.WARN)
+  end
   return true, "Opened draft buffer"
 end
 
@@ -131,7 +206,7 @@ function M.open_input_buffer(opts)
     bufnr = vim.api.nvim_create_buf(false, true)
     vim.api.nvim_buf_set_name(bufnr, "[Claude Input]")
     vim.bo[bufnr].buftype = "nofile"
-    vim.bo[bufnr].bufhidden = "wipe"
+    vim.bo[bufnr].bufhidden = "hide"
     vim.bo[bufnr].swapfile = false
     vim.bo[bufnr].filetype = "markdown"
     vim.bo[bufnr].modifiable = true
@@ -140,6 +215,7 @@ function M.open_input_buffer(opts)
   end
 
   vim.t.claude_input_bufnr = bufnr
+  tab_bufnr_registry[vim.api.nvim_get_current_tabpage()] = bufnr
   if opts.claude_bufnr and is_valid_buf(opts.claude_bufnr) then
     vim.t.claude_terminal_bufnr = opts.claude_bufnr
   end
@@ -175,7 +251,63 @@ function M.clear_draft()
   return true, "Claude draft buffer cleared"
 end
 
-function M.send_draft()
+-- claude-input のウィンドウを閉じる（バッファ・内容は保持）。
+-- フォーカスは vim.t.claude_input_prev_winid → claude_terminal_bufnr の window → Vim default の順で解決する。
+function M.hide()
+  local bufnr = get_draft_bufnr()
+  if not bufnr then
+    return false, "Claude draft buffer not found"
+  end
+
+  local windows = vim.fn.win_findbuf(bufnr)
+  if #windows == 0 then
+    return false, "Claude draft buffer is not visible"
+  end
+
+  -- フォーカス候補を閉じる前に確定する
+  local prev_winid = vim.t.claude_input_prev_winid
+  local fallback_winid
+  if is_valid_buf(vim.t.claude_terminal_bufnr) then
+    for _, winid in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+      if vim.api.nvim_win_is_valid(winid) and vim.api.nvim_win_get_buf(winid) == vim.t.claude_terminal_bufnr then
+        fallback_winid = winid
+        break
+      end
+    end
+  end
+
+  -- claude-input を表示している全ウィンドウを閉じる
+  for _, winid in ipairs(windows) do
+    if vim.api.nvim_win_is_valid(winid) then
+      pcall(vim.api.nvim_win_close, winid, false)
+    end
+  end
+
+  -- フォーカス復帰
+  local function try_focus(winid)
+    if winid and vim.api.nvim_win_is_valid(winid) then
+      vim.api.nvim_set_current_win(winid)
+      return true
+    end
+    return false
+  end
+
+  if not try_focus(prev_winid) then
+    try_focus(fallback_winid)
+  end
+
+  return true, "Claude draft buffer hidden"
+end
+
+function M.send_draft(opts)
+  opts = opts or {}
+  local hide_after
+  if opts.hide_after == nil then
+    hide_after = true
+  else
+    hide_after = opts.hide_after and true or false
+  end
+
   local bridge_ok, terminal_bridge = pcall(require, "terminal_bridge")
   if not bridge_ok then
     local message = "terminal_bridge module not found"
@@ -221,6 +353,22 @@ function M.send_draft()
     return false, message
   end
 
+  -- 送信成功後、内部で clear と（オプションで）hide を実行する
+  M.clear_draft()
+  if hide_after then
+    M.hide()
+  end
+
+  -- 送信後は常に target terminal の window にフォーカスを移す（hide() の prev_winid 復帰より優先）
+  if is_valid_buf(claude_bufnr) then
+    for _, winid in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+      if vim.api.nvim_win_is_valid(winid) and vim.api.nvim_win_get_buf(winid) == claude_bufnr then
+        vim.api.nvim_set_current_win(winid)
+        break
+      end
+    end
+  end
+
   return true, message
 end
 
@@ -233,9 +381,9 @@ function M.quote_to_draft(lines, opts)
     table.insert(quoted, "> " .. line)
   end
 
-  -- ドラフトバッファの取得・作成
+  -- ドラフトバッファの取得・作成・表示
   local draft_bufnr = get_draft_bufnr()
-  local need_open = draft_bufnr == nil
+  local need_open = draft_bufnr == nil or #vim.fn.win_findbuf(draft_bufnr) == 0
 
   if need_open then
     local success, message = M.focus_or_open({
@@ -288,6 +436,42 @@ function M.quote_to_draft(lines, opts)
   vim.cmd("startinsert|normal! $")
 
   return true, "Quoted " .. #quoted .. " lines to draft"
+end
+
+-- タブ閉じ時に、そのタブの claude-input バッファを wipe するための autocmd を登録する。
+-- bufhidden = "hide" に変更したことによるバッファ残存・命名衝突を防ぐ。
+-- 1 セッションで 1 回だけ呼べばよい。
+function M.setup()
+  if setup_done then
+    return
+  end
+  setup_done = true
+
+  local group = vim.api.nvim_create_augroup("ClaudeInputTabCleanup", { clear = true })
+
+  vim.api.nvim_create_autocmd("TabClosed", {
+    group = group,
+    callback = function()
+      -- 現存タブが参照している bufnr は残す
+      local live_bufnrs = {}
+      for _, tabpage in ipairs(vim.api.nvim_list_tabpages()) do
+        local ok, bufnr = pcall(vim.api.nvim_tabpage_get_var, tabpage, "claude_input_bufnr")
+        if ok and is_valid_buf(bufnr) then
+          live_bufnrs[bufnr] = true
+        end
+      end
+
+      -- 無効になった tabpage に紐づく bufnr を削除
+      for tabpage, bufnr in pairs(tab_bufnr_registry) do
+        if not vim.api.nvim_tabpage_is_valid(tabpage) then
+          tab_bufnr_registry[tabpage] = nil
+          if is_valid_buf(bufnr) and not live_bufnrs[bufnr] then
+            pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
+          end
+        end
+      end
+    end,
+  })
 end
 
 return M

--- a/conf/.config/nvim/lua/claude_input.lua
+++ b/conf/.config/nvim/lua/claude_input.lua
@@ -346,6 +346,17 @@ function M.send_draft(opts)
   end
 
   local target = target_index or target_pattern
+
+  -- 送信前に claude-input を hide して、claudecode 側の window を拡張後のサイズに整える
+  -- （送信直後に hide すると claudecode TUI の描画途中で resize が割り込み、行の残像や重複が発生する）
+  -- redraw だけでは Vim 内部の描画のみで、子プロセス claudecode の SIGWINCH 受信 → 再描画 ANSI 出力 → Vim ターミナル描画
+  -- までは同期されないため、vim.wait で短時間イベントループを回してから送信する
+  if hide_after then
+    M.hide()
+    vim.cmd("redraw")
+    vim.wait(250)
+  end
+
   local success, message =
     terminal_bridge.send_command(target, content, { add_newline = true, exclude_current = false })
   if not success then
@@ -353,11 +364,8 @@ function M.send_draft(opts)
     return false, message
   end
 
-  -- 送信成功後、内部で clear と（オプションで）hide を実行する
+  -- 送信成功後、draft の内容をクリア
   M.clear_draft()
-  if hide_after then
-    M.hide()
-  end
 
   -- 送信後は常に target terminal の window にフォーカスを移す（hide() の prev_winid 復帰より優先）
   if is_valid_buf(claude_bufnr) then

--- a/conf/.config/nvim/lua/terminal_bridge.lua
+++ b/conf/.config/nvim/lua/terminal_bridge.lua
@@ -161,23 +161,12 @@ function M.send_command(target, command, opts)
     return false, err_msg
   end
 
-  -- 改行が必要な場合、ターミナルバッファに移動してEnterキーをシミュレート
+  -- 改行が必要な場合、ジョブに直接 "\r" を送って同期的に実行させる
+  -- feedkeys + window切替は typeahead キューに入るため、呼び出し元が直後に window を切り替えると取りこぼされる
   if add_newline then
-    local current_win = vim.api.nvim_get_current_win()
-    -- ターミナルバッファのウィンドウを探す
-    for _, win in ipairs(vim.api.nvim_list_wins()) do
-      if vim.api.nvim_win_get_buf(win) == terminal.bufnr then
-        vim.api.nvim_set_current_win(win)
-        -- ターミナルモードに入ってEnterを送信
-        vim.cmd("startinsert")
-        vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<CR>", true, false, true), "t", false)
-        -- 元のウィンドウに戻る
-        -- vim.defer_fn(function()
-        --   vim.cmd("stopinsert")
-        --   vim.api.nvim_set_current_win(current_win)
-        -- end, 50)
-        break
-      end
+    local ok_nl, err_nl = pcall(vim.fn.chansend, terminal.job_id, "\r")
+    if not ok_nl then
+      M.log("WARN", "Failed to send newline: " .. tostring(err_nl))
     end
   end
 


### PR DESCRIPTION
## Summary

- claude-input バッファに hide/show トグル機能を追加。Alt+A で外からは focus、バッファ内からは hide に動作する
- 送信時フロー（`<C-CR>`）を「hide → redraw → wait → send → clear → target focus」に再構成し、描画崩れと focus 問題を解消
- `terminal_bridge.send_command` の `<CR>` 送信を `feedkeys` → `chansend("\r")` に変更し同期化
- `open_split_below_target` で split 後に target terminal の cursor を最終行へ移動し、最下部が見える状態を維持

Closes #237

## 背景

claude-input は claudecode.nvim のターミナルに送信する下書き用バッファで、`ClaudeAI` / `DualAI` / `DualClaude` など複数レイアウトから再利用されている。常時表示されるため claudecode window を圧迫していた。

## 設計決定

1. Hide = ウィンドウを閉じる。バッファと内容は保持
2. Show 位置 = `vim.t.claude_terminal_bufnr` のウィンドウの真下 → 見つからなければ pattern 再探索 → それも無ければ `botright split`
3. Alt+A トグル = 外から押せば focus、claude-input 内から押せば hide
4. Hide 後のフォーカス = `vim.t.claude_input_prev_winid` → `claude_terminal_bufnr` → Vim default
5. `bufhidden = "wipe"` → `"hide"` に変更。`TabClosed` で bufnr を削除し孤児化防止
6. 送信時 hide = `send_draft({ hide_after = true })` をデフォルトとし、`<C-CR>` で送信
7. Alt+A が terminal buffer から押された時、current terminal を `claude_terminal_bufnr` に再リンク
8. 送信後フォーカス = 常に `claude_terminal_bufnr` のウィンドウに移動（prev_winid より優先）
9. `<CR>` 送信 = `chansend(job_id, "\r")` で同期化
10. claudecode TUI の resize 再描画を待つため hide 後に `vim.wait(250)` を挟む
11. split 後に target terminal の cursor を最終行へ移動して最下部を常に可視化

## 変更ファイル

- `conf/.config/nvim/lua/claude_input.lua` +230/-18
- `conf/.config/nvim/lua/ai.lua` +16/-16
- `conf/.config/nvim/lua/terminal_bridge.lua` +6/-15

## Test plan

- [x] `:ClaudeAI` 実行 → claudecode と claude-input が上下で表示される
- [x] Alt+A で claude-input にフォーカス → もう一度 Alt+A で hide、claudecode にフォーカス戻る
- [x] ファイルを開いた状態から Alt+A → claudecode の下に claude-input が再表示される
- [x] `<C-CR>` で送信 → 送信即時実行 + claude-input が hide + focus が claudecode に移動
- [x] 送信直後のターミナル表示に描画崩れがない（残像・二重線・出力混在なし）
- [x] claude-input 書きかけ文章を残して hide → 別ファイル編集 → show で書きかけが残っている
- [x] Alt+A で claude-input を開いた時、claudecode の最下部（最新出力）が visible 領域に表示される
- [ ] 新しい claudecode terminal 上で Alt+A → claude-input がそちらの下に付く、送信もそちらに届く
- [ ] `:ClaudeAI` で新タブを開き、別タブを作成して戻ってきて `:tabclose` する → `:ls!` で `[Claude Input]` バッファが残っていない
- [ ] claude 系 terminal が無い状態で Alt+A → `botright split` で画面最下部に claude-input が出る、または notify が出る
- [ ] `:DualClaude` 従来通り動作（既知の副作用: `<C-CR>` で claude-input が hide されレイアウトが崩れる、別対応）

## 既知の制限

- DualClaude 利用時、`<C-CR>` 送信で claude-input が hide されレイアウトが崩れる。`dual_claude.lua` 側で `send_draft({ hide_after = false })` を直接呼ぶ等の対応が必要（本 PR の範囲外）
- `ClaudeDraftFocus` コマンドが `claudecode.lua` で参照されているが未定義（別対応）

🤖 Generated with [Claude Code](https://claude.com/claude-code)