### PR TITLE
[codex] automate node tools updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,6 @@ apply-nix-just-darwin:
 	sudo nix run nix-darwin -- switch --flake .#happy-darwin
 		
 update-apply-npm:
-	cd conf/.config/nix/node-pkgs && rm package-lock.json
-	cd conf/.config/nix/node-pkgs && npm install --package-lock-only
-	nix run nixpkgs#home-manager -- switch --flake .#myHomeConfig-darwin
-
+	scripts/update-node-tools.sh --force
 
 

--- a/conf/.config/hammerspoon/init.lua
+++ b/conf/.config/hammerspoon/init.lua
@@ -8,6 +8,7 @@ hs.application.enableSpotlightForNameSearches(true)
 -- dofile(hs.configdir .. "/modules/macskk.lua")
 dofile(hs.configdir .. "/modules/org-sync.lua")
 dofile(hs.configdir .. "/modules/skk-sync.lua")
+dofile(hs.configdir .. "/modules/node-tools-update.lua")
 -- dofile(hs.configdir .. "/modules/discord-mute.lua")
 dofile(hs.configdir .. "/modules/google-meet-mute.lua")
 dofile(hs.configdir .. "/modules/octo.lua")
@@ -16,5 +17,4 @@ dofile(hs.configdir .. "/modules/keybindings.lua")
 local log = hs.logger.new("myLogger", "debug")
 
 hs.alert.show("メイン設定ファイルを読み込みました")
-
 

--- a/conf/.config/hammerspoon/modules/node-tools-update.lua
+++ b/conf/.config/hammerspoon/modules/node-tools-update.lua
@@ -1,0 +1,101 @@
+NodeToolsUpdate = {}
+NodeToolsUpdate.logger = hs.logger.new("node-tools-update", "info")
+
+local repoPath = os.getenv("DOTFILES_DIR") or (os.getenv("HOME") .. "/src/github.com/happy663/dotfiles")
+local maxRetries = 5
+local retryDelay = 30
+local isRunning = false
+
+local function notify(title, text)
+  hs.notify
+    .new({
+      title = title,
+      informativeText = text,
+      soundName = hs.notify.defaultNotificationSound,
+    })
+    :send()
+end
+
+local function parseResult(stdOut)
+  local result = {}
+  for line in (stdOut or ""):gmatch("[^\r\n]+") do
+    local key, value = line:match("^([A-Z_]+)=(.*)$")
+    if key then
+      result[key] = value
+    end
+  end
+  return result
+end
+
+local function runUpdateScript()
+  local command = string.format("cd %q && scripts/update-node-tools.sh", repoPath)
+  NodeToolsUpdate.logger.i("Running: " .. command)
+
+  local task = hs.task.new("/bin/zsh", function(exitCode, stdOut, stdErr)
+    isRunning = false
+    local result = parseResult(stdOut)
+    local status = result.RESULT or "failed"
+    local logFile = result.LOG_FILE or ""
+
+    NodeToolsUpdate.logger.i("update-node-tools finished: exit=" .. tostring(exitCode) .. ", result=" .. status)
+    if stdErr and stdErr ~= "" then
+      NodeToolsUpdate.logger.w(stdErr)
+    end
+
+    if status == "updated" then
+      notify("nodeTools更新完了", "ログ: " .. logFile)
+    elseif status == "failed" or exitCode ~= 0 then
+      local stage = result.FAILED_STAGE or "unknown"
+      local lockfileState = result.LOCKFILE_STATE or "unknown"
+      notify("nodeTools更新失敗", "stage: " .. stage .. "\nlockfile: " .. lockfileState .. "\nログ: " .. logFile)
+    end
+  end, { "-lc", command })
+
+  if not task:start() then
+    isRunning = false
+    notify("nodeTools更新失敗", "更新スクリプトの起動に失敗しました")
+  end
+end
+
+local function checkNetworkThenRun(attempt)
+  local task = hs.task.new("/usr/bin/curl", function(exitCode)
+    if exitCode == 0 then
+      NodeToolsUpdate.logger.i("npm registry is reachable")
+      runUpdateScript()
+      return
+    end
+
+    if attempt < maxRetries then
+      NodeToolsUpdate.logger.w("npm registry is not reachable; retrying")
+      hs.timer.doAfter(retryDelay, function()
+        checkNetworkThenRun(attempt + 1)
+      end)
+      return
+    end
+
+    isRunning = false
+    notify("nodeTools更新失敗", "npm registryに接続できませんでした")
+  end, { "-fsS", "--head", "https://registry.npmjs.org/" })
+
+  if not task:start() then
+    isRunning = false
+    notify("nodeTools更新失敗", "ネットワーク確認を開始できませんでした")
+  end
+end
+
+NodeToolsUpdate.watcher = hs.caffeinate.watcher.new(function(eventType)
+  if eventType ~= hs.caffeinate.watcher.systemDidWake then
+    return
+  end
+
+  if isRunning then
+    NodeToolsUpdate.logger.i("Update is already running")
+    return
+  end
+
+  isRunning = true
+  checkNetworkThenRun(1)
+end)
+
+NodeToolsUpdate.watcher:start()
+NodeToolsUpdate.logger.i("nodeTools update watcher started")

--- a/conf/.config/nix/home-manager/common.nix
+++ b/conf/.config/nix/home-manager/common.nix
@@ -5,10 +5,7 @@ let
   username = "happy";
 
   # npmパッケージをNixで管理
-  nodeTools = pkgs.importNpmLock.buildNodeModules {
-    npmRoot = ../node-pkgs;
-    nodejs = pkgs.nodejs_24;
-  };
+  nodeTools = import ../node-pkgs { inherit pkgs; };
 in
 {
   nixpkgs = {
@@ -254,5 +251,4 @@ in
   # gitignore_globalを削除する
   home.file.".gitignore_global".enable = false;
 }
-
 

--- a/conf/.config/nix/node-pkgs/default.nix
+++ b/conf/.config/nix/node-pkgs/default.nix
@@ -1,0 +1,6 @@
+{ pkgs, nodejs ? pkgs.nodejs_24 }:
+
+pkgs.importNpmLock.buildNodeModules {
+  npmRoot = ./.;
+  inherit nodejs;
+}

--- a/flake.nix
+++ b/flake.nix
@@ -35,6 +35,7 @@
       };
       darwinPkgs = nixpkgs.legacyPackages.${system.darwin};
       linuxPkgs = nixpkgs.legacyPackages.${system.linux};
+      nodeToolsFor = pkgs: import ./conf/.config/nix/node-pkgs { inherit pkgs; };
       overlays = [
         inputs.neovim-nightly-overlay.overlays.default
       ];
@@ -68,6 +69,15 @@
           '');
       };
 
+      packages.${system.darwin} = rec {
+        nodeTools = nodeToolsFor darwinPkgs;
+        default = nodeTools;
+      };
+
+      packages.${system.linux} = rec {
+        nodeTools = nodeToolsFor linuxPkgs;
+        default = nodeTools;
+      };
 
       homeConfigurations = {
 

--- a/scripts/update-node-tools.sh
+++ b/scripts/update-node-tools.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+set -u
+
+force=0
+for arg in "$@"; do
+  case "$arg" in
+    --force)
+      force=1
+      ;;
+    *)
+      echo "unknown argument: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+node_pkgs_dir="$repo_root/conf/.config/nix/node-pkgs"
+lockfile="$node_pkgs_dir/package-lock.json"
+state_home="${XDG_STATE_HOME:-$HOME/.local/state}"
+state_dir="$state_home/dotfiles"
+last_success_file="$state_dir/update-node-tools.last-success"
+lock_dir="$state_dir/update-node-tools.lock"
+log_file="$state_dir/update-node-tools.log"
+today="$(date '+%Y-%m-%d')"
+
+mkdir -p "$state_dir"
+
+emit() {
+  printf '%s\n' "$*" >&3
+}
+
+mark_success() {
+  printf '%s\n' "$today" > "$last_success_file"
+}
+
+rotate_logs() {
+  rm -f "$log_file.5"
+  for i in 4 3 2 1; do
+    if [ -f "$log_file.$i" ]; then
+      mv "$log_file.$i" "$log_file.$((i + 1))"
+    fi
+  done
+  if [ -f "$log_file" ]; then
+    mv "$log_file" "$log_file.1"
+  fi
+  : > "$log_file"
+}
+
+cleanup_lock() {
+  if [ -d "$lock_dir" ] && [ "$(cat "$lock_dir/pid" 2>/dev/null || true)" = "$$" ]; then
+    rm -f "$lock_dir/pid" "$lock_dir/started_at"
+    rmdir "$lock_dir" 2>/dev/null || true
+  fi
+}
+
+fail_result() {
+  stage="$1"
+  lockfile_state="$2"
+  emit "RESULT=failed"
+  emit "FAILED_STAGE=$stage"
+  emit "LOCKFILE_STATE=$lockfile_state"
+  emit "LOG_FILE=$log_file"
+  exit 1
+}
+
+if [ "$force" -eq 0 ] && [ -f "$last_success_file" ] && [ "$(cat "$last_success_file")" = "$today" ]; then
+  exec 3>&1
+  emit "RESULT=skipped"
+  emit "LOG_FILE=$log_file"
+  exit 0
+fi
+
+exec 3>&1
+rotate_logs
+exec >> "$log_file" 2>&1
+
+echo "started_at=$(date '+%Y-%m-%d %H:%M:%S')"
+echo "repo_root=$repo_root"
+echo "force=$force"
+
+if ! mkdir "$lock_dir" 2>/dev/null; then
+  existing_pid="$(cat "$lock_dir/pid" 2>/dev/null || true)"
+  if [ -n "$existing_pid" ] && kill -0 "$existing_pid" 2>/dev/null; then
+    echo "another update-node-tools process is running: pid=$existing_pid"
+    emit "RESULT=locked"
+    emit "LOG_FILE=$log_file"
+    exit 0
+  fi
+
+  echo "removing stale lock: $lock_dir"
+  rm -f "$lock_dir/pid" "$lock_dir/started_at"
+  rmdir "$lock_dir" 2>/dev/null || true
+  if ! mkdir "$lock_dir" 2>/dev/null; then
+    echo "failed to acquire lock after stale cleanup"
+    fail_result "unknown" "unchanged"
+  fi
+fi
+
+printf '%s\n' "$$" > "$lock_dir/pid"
+date -u '+%Y-%m-%dT%H:%M:%SZ' > "$lock_dir/started_at"
+trap cleanup_lock EXIT
+
+case "$(uname -s)" in
+  Darwin)
+    home_config="myHomeConfig-darwin"
+    ;;
+  Linux)
+    home_config="myHomeConfig-linux"
+    ;;
+  *)
+    echo "unsupported system: $(uname -s)"
+    fail_result "unknown" "unchanged"
+    ;;
+esac
+
+backup="$(mktemp)"
+cleanup_backup() {
+  rm -f "$backup"
+}
+trap 'cleanup_backup; cleanup_lock' EXIT
+
+cp -p "$lockfile" "$backup"
+
+echo "updating npm lockfile"
+(
+  cd "$node_pkgs_dir" || exit 1
+  rm package-lock.json
+  npm install --package-lock-only
+)
+npm_status=$?
+if [ "$npm_status" -ne 0 ]; then
+  echo "npm lockfile update failed: status=$npm_status"
+  cp -p "$backup" "$lockfile"
+  fail_result "npm" "restored"
+fi
+
+if cmp -s "$backup" "$lockfile"; then
+  echo "package-lock.json is unchanged"
+  cp -p "$backup" "$lockfile"
+  mark_success
+  emit "RESULT=noop"
+  emit "LOG_FILE=$log_file"
+  exit 0
+fi
+
+echo "package-lock.json changed"
+echo "building nodeTools"
+(
+  cd "$repo_root" || exit 1
+  nix build --no-link .#nodeTools
+)
+build_status=$?
+if [ "$build_status" -ne 0 ]; then
+  echo "nix build failed: status=$build_status"
+  fail_result "build" "kept"
+fi
+
+echo "switching home-manager: $home_config"
+(
+  cd "$repo_root" || exit 1
+  nix run nixpkgs#home-manager -- switch --flake ".#$home_config"
+)
+switch_status=$?
+if [ "$switch_status" -ne 0 ]; then
+  echo "home-manager switch failed: status=$switch_status"
+  fail_result "switch" "kept"
+fi
+
+mark_success
+emit "RESULT=updated"
+emit "LOG_FILE=$log_file"


### PR DESCRIPTION
## Summary
- expose nodeTools as flake packages for macOS and Linux
- add a reusable nodeTools update script with daily skip, locking, logging, and rollback behavior
- run the updater from Hammerspoon on system wake after npm registry reachability checks

## Validation
- bash -n scripts/update-node-tools.sh
- luac -p conf/.config/hammerspoon/modules/node-tools-update.lua conf/.config/hammerspoon/init.lua
- nix build --no-link .#nodeTools
- nix build --no-link .#packages.aarch64-darwin.nodeTools
- nix build --no-link .#homeConfigurations.myHomeConfig-darwin.activationPackage
- nix eval .#packages.x86_64-linux.nodeTools.drvPath
- temporary XDG_STATE_HOME skipped-path check for scripts/update-node-tools.sh
- git diff --check

## Notes
- The force update path was not run because it can update package-lock.json and switch Home Manager.