### PR TITLE
feat: Hammerspoonでnode-pkgsを1日1回自動更新する (#249)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,5 +28,10 @@ update-apply-npm:
 	cd conf/.config/nix/node-pkgs && npm install --package-lock-only
 	nix run nixpkgs#home-manager -- switch --flake .#myHomeConfig-darwin
 
+# Hammerspoon等の自動実行から呼ぶ用。home-manager評価ファイルが
+# clean な場合のみ update-apply-npm を実行する。
+auto-update-node-pkgs:
+	scripts/auto-update-node-pkgs.sh
+
 
 

--- a/conf/.config/hammerspoon/init.lua
+++ b/conf/.config/hammerspoon/init.lua
@@ -11,10 +11,9 @@ dofile(hs.configdir .. "/modules/skk-sync.lua")
 -- dofile(hs.configdir .. "/modules/discord-mute.lua")
 dofile(hs.configdir .. "/modules/google-meet-mute.lua")
 dofile(hs.configdir .. "/modules/octo.lua")
+dofile(hs.configdir .. "/modules/auto-update.lua")
 dofile(hs.configdir .. "/modules/keybindings.lua")
 
 local log = hs.logger.new("myLogger", "debug")
 
 hs.alert.show("メイン設定ファイルを読み込みました")
-
-

--- a/conf/.config/hammerspoon/modules/auto-update.lua
+++ b/conf/.config/hammerspoon/modules/auto-update.lua
@@ -1,0 +1,137 @@
+-- node-pkgs自動更新モジュール
+-- スリープ復帰時に1日1回 `make auto-update-node-pkgs` を実行する。
+-- スクリプト側で home-manager 関連ファイルの dirty チェックと
+-- ネットワーク疎通確認を行う。
+AutoUpdate = {}
+AutoUpdate.logger = hs.logger.new("auto-update", "info")
+
+local home = os.getenv("HOME")
+local dotfilesPath = home .. "/src/github.com/happy663/dotfiles"
+local stateDir = home .. "/.cache/hammerspoon"
+local stateFile = stateDir .. "/auto-update-node-pkgs-last-run"
+
+-- 最終実行日（YYYY-MM-DD）を読み込む。なければnil。
+local function getLastRunDate()
+  local f = io.open(stateFile, "r")
+  if not f then
+    return nil
+  end
+  local date = f:read("*l")
+  f:close()
+  return date
+end
+
+-- 最終実行日を保存
+local function saveLastRunDate(date)
+  hs.fs.mkdir(stateDir)
+  local f = io.open(stateFile, "w")
+  if f then
+    f:write(date)
+    f:close()
+  end
+end
+
+local function today()
+  return os.date("%Y-%m-%d")
+end
+
+local function alreadyRanToday()
+  return getLastRunDate() == today()
+end
+
+-- 更新を実行
+local function runUpdate()
+  AutoUpdate.logger.i("Starting auto-update-node-pkgs ...")
+  hs.notify
+    .new({
+      title = "node-pkgs自動更新",
+      informativeText = "更新を開始します",
+    })
+    :send()
+
+  local task = hs.task.new("/usr/bin/make", function(exitCode, stdOut, stdErr)
+    AutoUpdate.logger.i("make exit=" .. tostring(exitCode))
+    if stdOut and stdOut ~= "" then
+      AutoUpdate.logger.i("stdout: " .. stdOut)
+    end
+    if stdErr and stdErr ~= "" then
+      AutoUpdate.logger.w("stderr: " .. stdErr)
+    end
+
+    if exitCode == 0 then
+      saveLastRunDate(today())
+      hs.notify
+        .new({
+          title = "node-pkgs自動更新完了",
+          informativeText = "更新が完了しました",
+        })
+        :send()
+    elseif exitCode == 2 then
+      -- home-manager評価ファイルがdirtyでスキップ。今日は再試行しない。
+      saveLastRunDate(today())
+      AutoUpdate.logger.i("Skipped: watched files dirty")
+      hs.notify
+        .new({
+          title = "node-pkgs自動更新スキップ",
+          informativeText = "home-manager関連ファイルに変更があるため今日はスキップ",
+        })
+        :send()
+    elseif exitCode == 3 then
+      -- ネットワーク未接続。state fileは更新しないので次回起動時に再試行。
+      AutoUpdate.logger.i("Skipped: no network")
+    else
+      hs.notify
+        .new({
+          title = "node-pkgs自動更新失敗",
+          informativeText = "exit " .. tostring(exitCode) .. " (詳細はlog参照)",
+          soundName = hs.notify.defaultNotificationSound,
+        })
+        :send()
+    end
+  end, { "-C", dotfilesPath, "auto-update-node-pkgs" })
+
+  -- PATHを引き継いでnix/npmを解決できるようにする
+  task:setEnvironment({
+    HOME = home,
+    PATH = (os.getenv("PATH") or "")
+      .. ":/run/current-system/sw/bin:"
+      .. home
+      .. "/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin",
+  })
+  task:start()
+end
+
+local function checkAndRun(reason)
+  AutoUpdate.logger.i("checkAndRun triggered: " .. (reason or "unknown"))
+  if alreadyRanToday() then
+    AutoUpdate.logger.i("Already ran today (" .. today() .. "), skipping")
+    return
+  end
+  runUpdate()
+end
+
+-- スリープ復帰イベントの監視
+AutoUpdate.watcher = hs.caffeinate.watcher.new(function(eventType)
+  if eventType == hs.caffeinate.watcher.systemDidWake then
+    AutoUpdate.logger.i("systemDidWake")
+    -- 復帰直後はネットワークが安定しないので少し待つ
+    hs.timer.doAfter(15, function()
+      checkAndRun("systemDidWake")
+    end)
+  end
+end)
+AutoUpdate.watcher:start()
+
+-- Hammerspoon起動・reload時にも1回だけチェック
+hs.timer.doAfter(10, function()
+  checkAndRun("startup")
+end)
+
+-- 手動実行用ホットキー（Cmd+Ctrl+U）
+hs.hotkey.bind({ "cmd", "ctrl" }, "U", function()
+  hs.alert.show("node-pkgs自動更新を手動実行...")
+  -- 手動実行時は当日チェックを無視
+  runUpdate()
+end)
+
+AutoUpdate.logger.i("Auto-update watcher started")

--- a/scripts/auto-update-node-pkgs.sh
+++ b/scripts/auto-update-node-pkgs.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Hammerspoonなどの自動実行から呼ばれることを想定。
+# home-managerが評価するファイルがdirtyでないことを確認してから
+# make update-apply-npm を実行する。
+#
+# Exit codes:
+#   0  : 更新成功
+#   2  : home-manager関連ファイルがdirtyでスキップ
+#   3  : ネットワーク未接続でスキップ
+#   その他: 実際の失敗
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# home-manager の myHomeConfig-darwin が評価するファイル群のうち、
+# 「ユーザーが手動編集する可能性があるもの」だけを監視対象にする。
+# nix-darwin (default.nix) や conf/.claude/* 等は home-manager の評価対象外なので除外。
+# package-lock.json はこのスクリプト自身が再生成するため除外（含めると2日目以降dirty判定でスキップし続ける）。
+WATCHED_FILES=(
+  "flake.nix"
+  "flake.lock"
+  "conf/.config/nix/home-manager/darwin.nix"
+  "conf/.config/nix/home-manager/common.nix"
+  "conf/.config/nix/node-pkgs/package.json"
+)
+
+DIRTY="$(git diff --name-only HEAD -- "${WATCHED_FILES[@]}")"
+if [[ -n "$DIRTY" ]]; then
+  echo "Skipping auto-update: home-manager related files are dirty:" >&2
+  echo "$DIRTY" >&2
+  exit 2
+fi
+
+if ! curl -sfI --max-time 5 https://registry.npmjs.org/ -o /dev/null; then
+  echo "Skipping auto-update: cannot reach registry.npmjs.org" >&2
+  exit 3
+fi
+
+echo "Running make update-apply-npm ..."
+exec make update-apply-npm


### PR DESCRIPTION
## Summary

closes #249

スリープ復帰時に1日1回 `make update-apply-npm` を自動実行する Hammerspoon モジュールを追加。claude / codex などの node-pkgs を意識せずに最新化する。

- `systemDidWake` で当日未実行＋home-manager関連ファイルが clean＋ネットワーク疎通OK を満たす場合に `make auto-update-node-pkgs` を実行
- 状態ファイル `~/.cache/hammerspoon/auto-update-node-pkgs-last-run` に最終実行日を記録
- 既存の `make update-apply-npm` は手動用にそのまま残す
- 手動トリガー: Cmd+Ctrl+U

## 設計メモ

home-manager評価対象だが「スクリプト自身が再生成する」`package-lock.json` は dirty 判定の対象から除外。含めると初回実行で dirty 状態になり、翌日以降ずっとスキップする。

watched files (dirty なら exit 2 でスキップ):
- `flake.nix`
- `flake.lock`
- `conf/.config/nix/home-manager/darwin.nix`
- `conf/.config/nix/home-manager/common.nix`
- `conf/.config/nix/node-pkgs/package.json`

`conf/.codex/*`、`conf/.claude/*`、`conf/.config/nix/nix-darwin/*` 等は home-manager の評価対象外なので watched から外し、編集中でも自動更新が動く。

## Exit codes

- `0`: 更新成功 → state file 更新
- `2`: watched files が dirty → 当日スキップ（state file 更新で再試行抑制）
- `3`: ネットワーク未接続 → 次回起動時に再試行（state file 据え置き）
- その他: 実際の失敗 → 通知

## 残課題（別タスク）

- 複数端末対応（cachix 連携 / GitHub Actions と整合させる）
- `update-apply-npm` の挙動が npm 以外も巻き込む件 → 今回の自動実行経路ではスクリプト側のセーフガードで抑止しているので一旦OK

## Test plan

- [ ] `chezmoi` 等で Hammerspoon 設定をリンクし `Hammerspoon → Reload Config`
- [ ] 起動から10秒後に通知「node-pkgs自動更新」が出る（初回時 / 再ロード時）
- [ ] Cmd+Ctrl+U で手動実行できる
- [ ] watched files を一時的に dirty にして実行 → 「スキップ」通知が出ることを確認
- [ ] 完了後 `~/.cache/hammerspoon/auto-update-node-pkgs-last-run` に当日日付が書かれている
- [ ] 翌日（または state file を消して）スリープ復帰時に再実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
