### PR TITLE
fix: auto-update の env と終了コード判定を修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,4 @@ update-apply-npm:
 	cd conf/.config/nix/node-pkgs && npm install --package-lock-only
 	nix run nixpkgs#home-manager -- switch --flake .#myHomeConfig-darwin
 
-# Hammerspoon等の自動実行から呼ぶ用。home-manager評価ファイルが
-# clean な場合のみ update-apply-npm を実行する。
-auto-update-node-pkgs:
-	scripts/auto-update-node-pkgs.sh
-
-
 

--- a/conf/.config/hammerspoon/modules/auto-update.lua
+++ b/conf/.config/hammerspoon/modules/auto-update.lua
@@ -7,8 +7,13 @@ AutoUpdate.logger = hs.logger.new("auto-update", "info")
 
 local home = os.getenv("HOME")
 local dotfilesPath = home .. "/src/github.com/happy663/dotfiles"
+local scriptPath = dotfilesPath .. "/scripts/auto-update-node-pkgs.sh"
 local stateDir = home .. "/.cache/hammerspoon"
 local stateFile = stateDir .. "/auto-update-node-pkgs-last-run"
+
+-- スクリプトの終了コード（scripts/auto-update-node-pkgs.sh と一致させる）
+local EXIT_SKIP_DIRTY = 10
+local EXIT_SKIP_NETWORK = 11
 
 -- 最終実行日（YYYY-MM-DD）を読み込む。なければnil。
 local function getLastRunDate()
@@ -49,8 +54,10 @@ local function runUpdate()
     })
     :send()
 
-  local task = hs.task.new("/usr/bin/make", function(exitCode, stdOut, stdErr)
-    AutoUpdate.logger.i("make exit=" .. tostring(exitCode))
+  -- 直接スクリプトを呼ぶ。makeを経由するとレシピ失敗時に終了コードが
+  -- 一律2に丸められるため、SKIPと実失敗の区別がつかなくなる。
+  local task = hs.task.new(scriptPath, function(exitCode, stdOut, stdErr)
+    AutoUpdate.logger.i("script exit=" .. tostring(exitCode))
     if stdOut and stdOut ~= "" then
       AutoUpdate.logger.i("stdout: " .. stdOut)
     end
@@ -66,7 +73,7 @@ local function runUpdate()
           informativeText = "更新が完了しました",
         })
         :send()
-    elseif exitCode == 2 then
+    elseif exitCode == EXIT_SKIP_DIRTY then
       -- home-manager評価ファイルがdirtyでスキップ。今日は再試行しない。
       saveLastRunDate(today())
       AutoUpdate.logger.i("Skipped: watched files dirty")
@@ -76,7 +83,7 @@ local function runUpdate()
           informativeText = "home-manager関連ファイルに変更があるため今日はスキップ",
         })
         :send()
-    elseif exitCode == 3 then
+    elseif exitCode == EXIT_SKIP_NETWORK then
       -- ネットワーク未接続。state fileは更新しないので次回起動時に再試行。
       AutoUpdate.logger.i("Skipped: no network")
     else
@@ -88,11 +95,17 @@ local function runUpdate()
         })
         :send()
     end
-  end, { "-C", dotfilesPath, "auto-update-node-pkgs" })
+  end, {})
 
-  -- PATHを引き継いでnix/npmを解決できるようにする
+  -- nix/npm/git/curl が解決できるPATHと、home-manager等が参照する
+  -- HOME/USER/LOGNAME/LANG をセットする。setEnvironmentは環境を完全に
+  -- 置き換えるので、必要なものは明示的に渡す必要がある。
+  local user = os.getenv("USER") or ""
   task:setEnvironment({
     HOME = home,
+    USER = user,
+    LOGNAME = os.getenv("LOGNAME") or user,
+    LANG = os.getenv("LANG") or "en_US.UTF-8",
     PATH = (os.getenv("PATH") or "")
       .. ":/run/current-system/sw/bin:"
       .. home

--- a/scripts/auto-update-node-pkgs.sh
+++ b/scripts/auto-update-node-pkgs.sh
@@ -3,11 +3,11 @@
 # home-managerが評価するファイルがdirtyでないことを確認してから
 # make update-apply-npm を実行する。
 #
-# Exit codes:
-#   0  : 更新成功
-#   2  : home-manager関連ファイルがdirtyでスキップ
-#   3  : ネットワーク未接続でスキップ
-#   その他: 実際の失敗
+# Exit codes（10/11 はGNU makeのError 2と衝突しないように2桁を採用）:
+#   0   : 更新成功
+#   10  : home-manager関連ファイルがdirtyでスキップ
+#   11  : ネットワーク未接続でスキップ
+#   その他: 実際の失敗（make/curl/git からの伝播）
 
 set -euo pipefail
 
@@ -30,12 +30,12 @@ DIRTY="$(git diff --name-only HEAD -- "${WATCHED_FILES[@]}")"
 if [[ -n "$DIRTY" ]]; then
   echo "Skipping auto-update: home-manager related files are dirty:" >&2
   echo "$DIRTY" >&2
-  exit 2
+  exit 10
 fi
 
 if ! curl -sfI --max-time 5 https://registry.npmjs.org/ -o /dev/null; then
   echo "Skipping auto-update: cannot reach registry.npmjs.org" >&2
-  exit 3
+  exit 11
 fi
 
 echo "Running make update-apply-npm ..."


### PR DESCRIPTION
## Summary

#250 のフォローアップ。実環境で動かしたところ2つの問題が判明したので修正する。あわせて死蔵になった Makefile ターゲットを削除する。

### 問題1: home-manager が `USER: unbound variable` で失敗

`hs.task` の `setEnvironment` は環境を完全置換するため、`HOME`/`PATH` しか渡しておらず `USER` が消えていた。`home-manager` のラッパースクリプトが `$USER` を参照しているので bail out していた。

→ `USER` / `LOGNAME` / `LANG` を明示的に追加。

### 問題2: SKIP と実失敗の終了コード衝突

GNU make はレシピ失敗を一律 `Error 2` に丸めるため、スクリプトの `exit 2` (SKIP_DIRTY) / `exit 3` (SKIP_NETWORK) と区別不能だった。実際 #250 マージ後の初回実行で home-manager 失敗が `Skipped: watched files dirty` 通知に化けた（ログ抜粋）:

```
make exit=2
... home-manager: line 158: USER: unbound variable
make[1]: *** [update-apply-npm] Error 1
make: *** [auto-update-node-pkgs] Error 2
Skipped: watched files dirty   ← 誤判定
```

問題は2層ある:

* 外側（Hammerspoon → make → script）: 外側 make がscriptの exit code を一律2に丸める
* 内側（script内の `exec make update-apply-npm`）: 内側 make 失敗で script 自身も exit 2 を返す

→ Hammerspoon から `make` を経由せずスクリプトを直接呼ぶ（外側を解消）＋ SKIP 用 exit code を `10` / `11` に変更（内側 make の `Error 2` と衝突しない領域に逃がす）。

### 死蔵になった Makefile ターゲットを削除

`auto-update-node-pkgs` Makefileターゲットは Hammerspoon が `make` 経由で呼ぶ前提で追加したが、上記修正で直接呼びに変えたため誰も使わなくなった。手動実行は `scripts/auto-update-node-pkgs.sh` を直接叩くか、safety check不要なら既存の `make update-apply-npm` で十分。

## Test plan

- [ ] PR をマージ → `rm ~/.cache/hammerspoon/auto-update-node-pkgs-last-run`
- [ ] Hammerspoon Reload Config
- [ ] Cmd+Ctrl+U で手動実行
- [ ] ログで `script exit=0` と「更新完了」通知を確認
- [ ] watched files (e.g. `common.nix`) を一時的に dirty にして実行 → `script exit=10` と「スキップ」通知
- [ ] Wi-Fi を切って実行 → `script exit=11` で state file が更新されないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)
