### PR TITLE
feat: 当日実行済みスキップ時も通知する

### DIFF
--- a/conf/.config/hammerspoon/modules/auto-update.lua
+++ b/conf/.config/hammerspoon/modules/auto-update.lua
@@ -80,7 +80,7 @@ local function runUpdate()
       hs.notify
         .new({
           title = "node-pkgs自動更新スキップ",
-          informativeText = "home-manager関連ファイルに変更があるため今日はスキップ",
+          informativeText = "home-manager関連ファイルに変更があるためスキップ",
         })
         :send()
     elseif exitCode == EXIT_SKIP_NETWORK then

--- a/conf/.config/hammerspoon/modules/auto-update.lua
+++ b/conf/.config/hammerspoon/modules/auto-update.lua
@@ -118,6 +118,12 @@ local function checkAndRun(reason)
   AutoUpdate.logger.i("checkAndRun triggered: " .. (reason or "unknown"))
   if alreadyRanToday() then
     AutoUpdate.logger.i("Already ran today (" .. today() .. "), skipping")
+    hs.notify
+      .new({
+        title = "node-pkgs自動更新スキップ",
+        informativeText = "本日 (" .. today() .. ") は実行済み",
+      })
+      :send()
     return
   end
   runUpdate()


### PR DESCRIPTION
## Summary

`checkAndRun` が「当日実行済み」で early-return する経路はログのみで通知が出ていなかったため、スリープ復帰や Hammerspoon 起動時に何も反応がなくて分かりづらかった。スキップ時にも通知を出すように変更する。

通知内容: 「node-pkgs自動更新スキップ / 本日 (YYYY-MM-DD) は実行済み」

## Test plan

- [ ] 本日分の state file が残っている状態で `Cmd+Ctrl+R` (Hammerspoon Reload Config) → 起動時のチェックでスキップ通知が出る
- [ ] スリープ→復帰でも同様にスキップ通知が出る
- [ ] state file を削除 (`rm ~/.cache/hammerspoon/auto-update-node-pkgs-last-run`) → 通常の更新フローが走り「更新完了」通知になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)
