### PR TITLE
feat: vim-tmux-navigator を導入して Neovim と tmux 間のシームレスなペイン移動を実現

### DIFF
--- a/conf/.config/nvim/lazy-lock.json
+++ b/conf/.config/nvim/lazy-lock.json
@@ -128,6 +128,7 @@
   "vim-kensaku-search": { "branch": "main", "commit": "9568c2b174a9cf31bd9922c0a991117f4dd4f0c3" },
   "vim-textobj-codeblock": { "branch": "master", "commit": "7658826f1a13a2865fb65b64481c40968fd780c1" },
   "vim-textobj-user": { "branch": "master", "commit": "41a675ddbeefd6a93664a4dc52f302fe3086a933" },
+  "vim-tmux-navigator": { "branch": "master", "commit": "e41c431a0c7b7388ae7ba341f01a0d217eb3a432" },
   "vim-translator": { "branch": "master", "commit": "6f0639c6d471a3a90ac19db96e1e379c030f74e3" },
   "vim-vsnip": { "branch": "master", "commit": "9bcfabea653abdcdac584283b5097c3f8760abaa" },
   "vimtex": { "branch": "master", "commit": "9f6a5bb0a9c9f1542fe88dc07511ce8401242e2a" },

--- a/conf/.config/nvim/lua/core/keymaps.lua
+++ b/conf/.config/nvim/lua/core/keymaps.lua
@@ -3,10 +3,7 @@ local map = vim.api.nvim_set_keymap
 local opts = { noremap = true, silent = true }
 
 -- Normal mode keymaps
-map("n", "<C-h>", "<C-w>h", opts)
-map("n", "<C-l>", "<C-w>l", opts)
-map("n", "<C-j>", "<C-w>j", opts)
-map("n", "<C-k>", "<C-w>k", opts)
+-- <C-h/j/k/l> は vim-tmux-navigator が担当
 
 -- easy-motion
 --
@@ -27,9 +24,8 @@ map("i", "<C-b>", "<Left>", opts)
 map("v", "<leader>/", "gcc", { noremap = false, silent = true })
 -- terminal mode
 -- escapeでnormal modeに戻る
-map("t", "<C-j>", [[<Cmd>wincmd j<CR>]], opts)
-map("t", "<C-l>", [[<Cmd>wincmd l<CR>]], opts)
-map("t", "<C-w>", [[<C-\><C-n><C-w>]], opts)
+-- <C-j/l> は vim-tmux-navigator が担当
+-- map("t", "<C-w>", [[<C-\><C-n><C-w>]], opts)
 
 -- 定義にジャンプする前に縦分割を行い、そのウィンドウで定義を開く関数
 _G.goto_definition_vsplit = function()

--- a/conf/.config/nvim/lua/plugins/navigation/tmux-navigator.lua
+++ b/conf/.config/nvim/lua/plugins/navigation/tmux-navigator.lua
@@ -20,17 +20,19 @@ return {
       -- { "<c-\\>", "<cmd><C-U>TmuxNavigatePrevious<cr>" },
     },
     config = function()
-      local directions = {
-        h = "Left",
-        j = "Down",
-        k = "Up",
-        l = "Right",
-      }
-
       local function is_agent_terminal(bufnr)
         local name = vim.api.nvim_buf_get_name(bufnr)
-        -- review-comment:%f[%A]って何？
         return vim.bo[bufnr].buftype == "terminal" and name:match(":(claude|codex)%f[%A]") ~= nil
+      end
+
+      local function set_terminal_tmux_navigate_keymap(bufnr, key, direction)
+        vim.keymap.set("t", "<C-" .. key .. ">", function()
+          vim.cmd("TmuxNavigate" .. direction)
+        end, {
+          buffer = bufnr,
+          silent = true,
+          desc = "Tmux navigate " .. direction,
+        })
       end
 
       local function set_agent_terminal_keymaps(bufnr)
@@ -38,16 +40,10 @@ return {
           return
         end
 
-        -- review-comment: for文使用しない方針の方が好きかな。関数定義してそれぞれ指定するとよさそう。10個ぐらいあるなら話は別だけど今回4個だし量が動的に増える訳でもない
-        for key, direction in pairs(directions) do
-          vim.keymap.set("t", "<C-" .. key .. ">", function()
-            vim.cmd("TmuxNavigate" .. direction)
-          end, {
-            buffer = bufnr,
-            silent = true,
-            desc = "Tmux navigate " .. direction,
-          })
-        end
+        set_terminal_tmux_navigate_keymap(bufnr, "h", "Left")
+        set_terminal_tmux_navigate_keymap(bufnr, "j", "Down")
+        set_terminal_tmux_navigate_keymap(bufnr, "k", "Up")
+        set_terminal_tmux_navigate_keymap(bufnr, "l", "Right")
       end
 
       vim.api.nvim_create_autocmd("TermOpen", {

--- a/conf/.config/nvim/lua/plugins/navigation/tmux-navigator.lua
+++ b/conf/.config/nvim/lua/plugins/navigation/tmux-navigator.lua
@@ -3,6 +3,7 @@ return {
     "christoomey/vim-tmux-navigator",
     lazy = false,
     init = function()
+      -- デフォルトキーマップを無効化して手動で設定する
       vim.g.tmux_navigator_no_mappings = 1
     end,
     cmd = {
@@ -20,14 +21,103 @@ return {
       -- { "<c-\\>", "<cmd><C-U>TmuxNavigatePrevious<cr>" },
     },
     config = function()
+      -- Claude / Codex の TUI が開かれている terminal buffer かどうかを判定する。
+      -- Lua pattern は | による OR をサポートしないため条件を2つに分けている。
       local function is_agent_terminal(bufnr)
         local name = vim.api.nvim_buf_get_name(bufnr)
-        return vim.bo[bufnr].buftype == "terminal" and name:match(":(claude|codex)%f[%A]") ~= nil
+        return vim.bo[bufnr].buftype == "terminal"
+          and (name:match(":claude%f[%A]") ~= nil or name:match(":codex%f[%A]") ~= nil)
       end
 
+      -- terminal job への control char 送信用。
+      -- keymap で C-h/j/k/l を捕まえると TUI 側に届かなくなるため、
+      -- 入力ありの場合は対応する ASCII バイトを job に直接送って補う。
+      local control_chars = {
+        h = "\008", -- BS (C-h)
+        j = "\010", -- LF (C-j)
+        k = "\011", -- VT (C-k)
+        l = "\012", -- FF (C-l)
+      }
+
+      -- カーソル行を見て「TUI 側への実入力があるか」を返す。
+      -- zsh の $BUFFER 相当を Neovim から直接取れないため、表示行をパースするヒューリスティック。
+      local function get_current_terminal_input(bufnr)
+        local cursor = vim.api.nvim_win_get_cursor(0)
+        local line = vim.api.nvim_buf_get_lines(bufnr, cursor[1] - 1, cursor[1], false)[1] or ""
+        -- Claude TUI の入力欄はスペースに NBSP (U+00A0) を使うため正規化する
+        local input = vim.trim(line:gsub("\xc2\xa0", " "))
+
+        -- 罫線のみの行（水平セパレータ）はカーソルが乗っても入力なし扱いにする
+        local border_only = input
+        for _, char in ipairs({
+          "─",
+          "━",
+          "═",
+          "┌",
+          "┐",
+          "└",
+          "┘",
+          "├",
+          "┤",
+          "┬",
+          "┴",
+          "┼",
+          "╭",
+          "╮",
+          "╰",
+          "╯",
+        }) do
+          border_only = border_only:gsub(char, "")
+        end
+
+        if vim.trim(border_only) == "" then
+          return ""
+        end
+
+        -- ボックス枠の縦線を両端から剥がして入力部分だけ残す
+        for _, char in ipairs({ "│", "┃", "║" }) do
+          input = vim.trim(input:gsub("^" .. char, ""):gsub(char .. "$", ""))
+        end
+
+        -- プロンプト記号の直後にカーソルがある場合はプレースホルダーとみなして空扱いにする。
+        -- Claude,Codex のプレースホルダー文言は動的に変化するためカーソル位置で判定する。
+        for _, prompt in ipairs({ ">", "›", "❯", "➜" }) do
+          if vim.startswith(input, prompt) then
+            local prompt_end = #prompt
+            local after_prompt = input:sub(prompt_end + 1)
+            local prompt_padding = after_prompt:match("^(%s*)") or ""
+
+            if cursor[2] <= prompt_end + #prompt_padding then
+              return ""
+            else
+              return vim.trim(after_prompt)
+            end
+          end
+        end
+
+        return input
+      end
+
+      local function send_control_char_to_terminal(bufnr, key)
+        local job_id = vim.b[bufnr].terminal_job_id
+        local control_char = control_chars[key]
+
+        if job_id and control_char then
+          vim.api.nvim_chan_send(job_id, control_char)
+        end
+      end
+
+      -- terminal-job mode 専用のキーマップを設定する。
+      -- 入力欄が空なら tmux/Neovim 間のペイン移動、入力中なら TUI へキーを転送する。
       local function set_terminal_tmux_navigate_keymap(bufnr, key, direction)
         vim.keymap.set("t", "<C-" .. key .. ">", function()
-          vim.cmd("TmuxNavigate" .. direction)
+          local input = get_current_terminal_input(bufnr)
+
+          if input == "" then
+            vim.cmd("TmuxNavigate" .. direction)
+          else
+            send_control_char_to_terminal(bufnr, key)
+          end
         end, {
           buffer = bufnr,
           silent = true,
@@ -46,6 +136,7 @@ return {
         set_terminal_tmux_navigate_keymap(bufnr, "l", "Right")
       end
 
+      -- 新規 terminal buffer が開かれたときにキーマップを設定する
       vim.api.nvim_create_autocmd("TermOpen", {
         desc = "Use tmux navigator keys in agent terminals without sending text to the TUI",
         callback = function(event)
@@ -53,6 +144,7 @@ return {
         end,
       })
 
+      -- プラグイン読み込み時点で既に開かれている terminal buffer にも適用する
       for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
         if vim.api.nvim_buf_is_loaded(bufnr) then
           set_agent_terminal_keymaps(bufnr)

--- a/conf/.config/nvim/lua/plugins/navigation/tmux-navigator.lua
+++ b/conf/.config/nvim/lua/plugins/navigation/tmux-navigator.lua
@@ -34,8 +34,8 @@ return {
       -- 入力ありの場合は対応する ASCII バイトを job に直接送って補う。
       local control_chars = {
         h = "\008", -- BS (C-h)
-        j = "\010", -- LF (C-j)
-        k = "\011", -- VT (C-k)
+        -- j = "\010", -- LF (C-j)
+        -- k = "\011", -- VT (C-k)
         l = "\012", -- FF (C-l)
       }
 
@@ -131,8 +131,9 @@ return {
         end
 
         set_terminal_tmux_navigate_keymap(bufnr, "h", "Left")
-        set_terminal_tmux_navigate_keymap(bufnr, "j", "Down")
-        set_terminal_tmux_navigate_keymap(bufnr, "k", "Up")
+        -- skkeletonの<C-j>と被っているのでDown/Upは無効にしておく
+        -- set_terminal_tmux_navigate_keymap(bufnr, "j", "Down")
+        -- set_terminal_tmux_navigate_keymap(bufnr, "k", "Up")
         set_terminal_tmux_navigate_keymap(bufnr, "l", "Right")
       end
 

--- a/conf/.config/nvim/lua/plugins/navigation/tmux-navigator.lua
+++ b/conf/.config/nvim/lua/plugins/navigation/tmux-navigator.lua
@@ -1,0 +1,67 @@
+return {
+  {
+    "christoomey/vim-tmux-navigator",
+    lazy = false,
+    init = function()
+      vim.g.tmux_navigator_no_mappings = 1
+    end,
+    cmd = {
+      "TmuxNavigateLeft",
+      "TmuxNavigateDown",
+      "TmuxNavigateUp",
+      "TmuxNavigateRight",
+      -- "TmuxNavigatePrevious",
+    },
+    keys = {
+      { "<c-h>", "<cmd>TmuxNavigateLeft<cr>" },
+      { "<c-j>", "<cmd>TmuxNavigateDown<cr>" },
+      { "<c-k>", "<cmd>TmuxNavigateUp<cr>" },
+      { "<c-l>", "<cmd>TmuxNavigateRight<cr>" },
+      -- { "<c-\\>", "<cmd><C-U>TmuxNavigatePrevious<cr>" },
+    },
+    config = function()
+      local directions = {
+        h = "Left",
+        j = "Down",
+        k = "Up",
+        l = "Right",
+      }
+
+      local function is_agent_terminal(bufnr)
+        local name = vim.api.nvim_buf_get_name(bufnr)
+        -- review-comment:%f[%A]って何？
+        return vim.bo[bufnr].buftype == "terminal" and name:match(":(claude|codex)%f[%A]") ~= nil
+      end
+
+      local function set_agent_terminal_keymaps(bufnr)
+        if not is_agent_terminal(bufnr) then
+          return
+        end
+
+        -- review-comment: for文使用しない方針の方が好きかな。関数定義してそれぞれ指定するとよさそう。10個ぐらいあるなら話は別だけど今回4個だし量が動的に増える訳でもない
+        for key, direction in pairs(directions) do
+          vim.keymap.set("t", "<C-" .. key .. ">", function()
+            vim.cmd("TmuxNavigate" .. direction)
+          end, {
+            buffer = bufnr,
+            silent = true,
+            desc = "Tmux navigate " .. direction,
+          })
+        end
+      end
+
+      vim.api.nvim_create_autocmd("TermOpen", {
+        desc = "Use tmux navigator keys in agent terminals without sending text to the TUI",
+        callback = function(event)
+          set_agent_terminal_keymaps(event.buf)
+        end,
+      })
+
+      for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+        if vim.api.nvim_buf_is_loaded(bufnr) then
+          set_agent_terminal_keymaps(bufnr)
+        end
+      end
+    end,
+  },
+}

--- a/conf/.config/tmux/tmux.conf
+++ b/conf/.config/tmux/tmux.conf
@@ -68,11 +68,26 @@ bind d split-window -v -c "#{pane_current_path}"
 bind v split-window -h -c "#{pane_current_path}"
 bind x confirm-before -p "kill-pane #P? (y/n)" kill-pane
 
-# ペイン移動 - vim風
+# ペイン移動 - vim風 (prefix付きバックアップ)
 bind h select-pane -L
 bind j select-pane -D
 bind k select-pane -U
 bind l select-pane -R
+
+# vim-tmux-navigator: C-h/j/k/l でNeovimウィンドウとtmuxペインをシームレスに移動
+# nvim/fzf → vim-tmux-navigator に委譲、zsh/bash → ZLE widget（バッファ空判定）に委譲
+# それ以外のプロセス（cat等）→ tmux が直接 select-pane
+should_forward_keys="ps -o state= -o comm= -t '#{pane_tty}' | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?(-?zsh|-?bash|g?(view|l?n?vim?x?|fzf))(diff)?$'"
+bind -n 'C-h' if-shell "$should_forward_keys" 'send-keys C-h' 'select-pane -L'
+bind -n 'C-j' if-shell "$should_forward_keys" 'send-keys C-j' 'select-pane -D'
+bind -n 'C-k' if-shell "$should_forward_keys" 'send-keys C-k' 'select-pane -U'
+bind -n 'C-l' if-shell "$should_forward_keys" 'send-keys C-l' 'select-pane -R'
+bind -n 'C-\' if-shell "$should_forward_keys" 'send-keys C-\\' 'select-pane -l'
+bind -T copy-mode-vi 'C-h' select-pane -L
+bind -T copy-mode-vi 'C-j' select-pane -D
+bind -T copy-mode-vi 'C-k' select-pane -U
+bind -T copy-mode-vi 'C-l' select-pane -R
+bind -T copy-mode-vi 'C-\' select-pane -l
 
 # リサイズモード
 bind e switch-client -T resize

--- a/conf/.config/zsh/keybindings.zsh
+++ b/conf/.config/zsh/keybindings.zsh
@@ -80,3 +80,39 @@ zle -N ghq-list
 bindkey '^g' ghq-list
 
 
+# -----------------------------------------------------------------------------
+# vim-tmux-navigator: バッファ空判定によるシームレスなペイン移動
+# バッファが空の時はtmuxペイン移動、入力中は通常のreadline操作
+# -----------------------------------------------------------------------------
+function _tmux_navigate_or() {
+  local pane_dir=$1
+  local fallback=$2
+  if [[ -n $TMUX && -z $BUFFER ]]; then
+    tmux select-pane $pane_dir
+  else
+    zle $fallback
+  fi
+}
+
+function _navigate_left()  { _tmux_navigate_or -L backward-delete-char }
+function _navigate_right() {
+  if [[ -n $TMUX && -z $BUFFER ]]; then
+    tmux select-pane -R
+  else
+    zle -I
+    clear
+    zle reset-prompt
+  fi
+}
+function _navigate_down()  { _tmux_navigate_or -D accept-line }
+function _navigate_up()    { _tmux_navigate_or -U kill-line }
+
+zle -N _navigate_left
+zle -N _navigate_right
+zle -N _navigate_down
+zle -N _navigate_up
+
+bindkey '^h' _navigate_left
+bindkey '^l' _navigate_right
+bindkey '^j' _navigate_down
+bindkey '^k' _navigate_up


### PR DESCRIPTION
## Summary

- `vim-tmux-navigator` を導入し、C-h/j/k/l で Neovim と tmux のペインをまたいで移動できるようにした
- Claude / Codex などの AI TUI を Neovim の terminal buffer で開いているとき、入力有無に応じて tmux navigation と TUI へのキー転送を自動で切り替える

## 主な変更

- `conf/.config/nvim/lua/plugins/navigation/tmux-navigator.lua`: プラグイン設定と terminal-job mode 対応ロジック
  - `is_agent_terminal`: バッファ名から Claude/Codex の terminal を判定
  - `get_current_terminal_input`: カーソル行をパースして実入力の有無を判定（NBSP 正規化・罫線スキップ・プロンプト位置判定）
  - 入力なし → `TmuxNavigate*`、入力あり → control char を terminal job に転送
- `conf/.config/tmux/tmux.conf`: vim-tmux-navigator 連携設定を追加
- `conf/.config/zsh/keybindings.zsh`: zsh prompt での C-h/j/k/l 分岐（`$BUFFER` が空なら tmux 移動）

## Test plan

- [ ] 通常の Neovim window で C-h/j/k/l が tmux/Neovim ペイン移動として動作する
- [ ] Claude terminal buffer で入力欄が空のとき C-h/j/k/l がペイン移動になる
- [ ] Claude terminal buffer で入力中は C-h/j/k/l が TUI 側へ転送される（カーソル移動・削除）
- [ ] Codex terminal buffer で同様の動作が確認できる
- [ ] zsh prompt で `$BUFFER` が空なら tmux 移動、入力中なら通常のカーソル操作になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)