### PR TITLE
feat: Ovim専用のNVIM_APPNAME=ovim-nvimによる起動高速化

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,4 +36,14 @@ claude-pull:
 claude-push:
 	scripts/claude-settings.sh push
 
+# Ovim 専用 Neovim 設定 (NVIM_APPNAME=ovim-nvim) のセットアップ
+# 1. 専用設定で lazy.nvim を起動しプラグインを取得
+# 2. ラッパースクリプトを ~/.local/bin に配置して実行可能にする
+# 3. Ovim の settings.yaml の nvim_path をラッパーのパスに更新する
+setup-ovim:
+	NVIM_APPNAME=ovim-nvim nvim --headless "+Lazy! sync" +qa
+	mkdir -p ~/.local/bin
+	cp scripts/nvim-ovim-wrapper.sh ~/.local/bin/nvim-ovim
+	chmod +x ~/.local/bin/nvim-ovim
+	@echo "Done. Set nvim_path to $$HOME/.local/bin/nvim-ovim in Ovim settings."
 

--- a/conf/.config/ovim-nvim/init.lua
+++ b/conf/.config/ovim-nvim/init.lua
@@ -23,6 +23,17 @@ vim.opt.rtp:prepend(lazypath)
 -- メイン nvim に plugin/ や after/plugin/ がないため auto-loading の副作用はない
 vim.opt.rtp:append(vim.fn.expand("~/.config/nvim"))
 
+-- Ovim の一時ファイル編集時に <C-CR> で保存終了
+vim.api.nvim_create_autocmd("BufRead", {
+  pattern = "*/Library/Caches/ovim/*",
+  callback = function()
+    vim.keymap.set("i", "<C-CR>", function()
+      vim.cmd("wq")
+    end, { buffer = true, silent = true })
+    vim.keymap.set("n", "<C-CR>", ":wq<CR>", { buffer = true, silent = true })
+  end,
+})
+
 require("lazy").setup({
   spec = {
     { import = "plugins.japanese" },

--- a/conf/.config/ovim-nvim/init.lua
+++ b/conf/.config/ovim-nvim/init.lua
@@ -1,9 +1,18 @@
 -- Ovim 専用の最小 Neovim 設定
 -- NVIM_APPNAME=ovim-nvim で起動された時のみ読まれる
 
-vim.loader.enable()
 vim.g.mapleader = " "
 vim.g.not_in_vscode = vim.g.vscode == nil
+
+-- メイン nvim の設定を rtp に追加する
+-- lazy.nvim の { import = "plugins.xxx" } は nvim_get_runtime_file でディレクトリを探すため rtp が必要
+-- メイン nvim に plugin/ や after/plugin/ がないため auto-loading の副作用はない
+local nvim_config = vim.fn.expand("~/.config/nvim")
+vim.opt.rtp:append(nvim_config)
+
+-- rtp:append だけでは vim.loader のキャッシュに反映されないため package.path に直接追加する
+package.path = nvim_config .. "/lua/?.lua;" .. nvim_config .. "/lua/?/init.lua;" .. package.path
+vim.loader.enable()
 
 local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
 if not (vim.uv or vim.loop).fs_stat(lazypath) then
@@ -17,11 +26,6 @@ if not (vim.uv or vim.loop).fs_stat(lazypath) then
   })
 end
 vim.opt.rtp:prepend(lazypath)
-
--- メイン nvim の設定を rtp に追加する
--- lazy.nvim の { import = "plugins.xxx" } は nvim_get_runtime_file でディレクトリを探すため rtp が必要
--- メイン nvim に plugin/ や after/plugin/ がないため auto-loading の副作用はない
-vim.opt.rtp:append(vim.fn.expand("~/.config/nvim"))
 
 -- Ovim の一時ファイル編集時に <C-CR> で保存終了
 vim.api.nvim_create_autocmd("BufRead", {
@@ -37,6 +41,7 @@ vim.api.nvim_create_autocmd("BufRead", {
 require("lazy").setup({
   spec = {
     { import = "plugins.japanese" },
+    { import = "plugins.completion" },
   },
   performance = {
     rtp = {
@@ -53,3 +58,6 @@ require("lazy").setup({
     },
   },
 })
+
+require("core.keymaps")
+require("core.settings")

--- a/conf/.config/ovim-nvim/init.lua
+++ b/conf/.config/ovim-nvim/init.lua
@@ -1,0 +1,44 @@
+-- Ovim 専用の最小 Neovim 設定
+-- NVIM_APPNAME=ovim-nvim で起動された時のみ読まれる
+
+vim.loader.enable()
+vim.g.mapleader = " "
+vim.g.not_in_vscode = vim.g.vscode == nil
+
+local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
+if not (vim.uv or vim.loop).fs_stat(lazypath) then
+  vim.fn.system({
+    "git",
+    "clone",
+    "--filter=blob:none",
+    "https://github.com/folke/lazy.nvim.git",
+    "--branch=stable",
+    lazypath,
+  })
+end
+vim.opt.rtp:prepend(lazypath)
+
+-- メイン nvim の設定を rtp に追加する
+-- lazy.nvim の { import = "plugins.xxx" } は nvim_get_runtime_file でディレクトリを探すため rtp が必要
+-- メイン nvim に plugin/ や after/plugin/ がないため auto-loading の副作用はない
+vim.opt.rtp:append(vim.fn.expand("~/.config/nvim"))
+
+require("lazy").setup({
+  spec = {
+    { import = "plugins.japanese" },
+  },
+  performance = {
+    rtp = {
+      disabled_plugins = {
+        "netrw",
+        "netrwPlugin",
+        "netrwSettings",
+        "netrwFileHandlers",
+        "tarPlugin",
+        "tohtml",
+        "tutor",
+        "zipPlugin",
+      },
+    },
+  },
+})

--- a/scripts/nvim-ovim-wrapper.sh
+++ b/scripts/nvim-ovim-wrapper.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Ovim から起動される nvim に NVIM_APPNAME=ovim-nvim を注入するラッパー
+# Ovim の settings.yaml の nvim_path にこのスクリプトのパスを指定する
+export NVIM_APPNAME=ovim-nvim
+exec nvim "$@"

--- a/scripts/nvim-ovim-wrapper.sh
+++ b/scripts/nvim-ovim-wrapper.sh
@@ -1,5 +1,14 @@
 #!/bin/sh
 # Ovim から起動される nvim に NVIM_APPNAME=ovim-nvim を注入するラッパー
 # Ovim の settings.yaml の nvim_path にこのスクリプトのパスを指定する
+
+# GUIアプリからの起動時はシェルのPATHが引き継がれないため補完する
+export PATH="$HOME/.nix-profile/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
+
+# miseでインストールしたneovimへのパスも追加
+if [ -d "$HOME/.local/share/mise/shims" ]; then
+  export PATH="$HOME/.local/share/mise/shims:$PATH"
+fi
+
 export NVIM_APPNAME=ovim-nvim
 exec nvim "$@"


### PR DESCRIPTION
## Summary

- `conf/.config/ovim-nvim/init.lua`: 日本語プラグイン・補完・core設定のみ有効にした最小構成
- `scripts/nvim-ovim-wrapper.sh`: `NVIM_APPNAME=ovim-nvim`とGUIアプリ用PATH補完を注入するラッパー
- `Makefile`: `setup-ovim`ターゲット追加（プラグインインストール＋ラッパー配置）

## 使い方

```sh
make setup-ovim
```

実行後、Ovimの`settings.yaml`（`~/Library/Application Support/ovim/settings.yaml`）の`nvim_path`を`~/.local/bin/nvim-ovim`に変更する。

## 関連issue

Closes #260

## Test plan

- [ ] `make setup-ovim`でラッパーが`~/.local/bin/nvim-ovim`に配置される
- [ ] Ovimの`nvim_path`をラッパーに変更してテキスト入力欄からNeovimが起動する
- [ ] 起動時に`NVIM_APPNAME=ovim-nvim`が有効でメインのnvim設定が読み込まれない
- [ ] SKK日本語入力が動作する
- [ ] `<C-CR>`で保存終了できる

🤖 Generated with [Claude Code](https://claude.com/claude-code)