### PR TITLE
feat: AgentタブとファイルタブをシームレスにするタブルーティングをNeovimに追加

### DIFF
--- a/conf/.config/nvim/lua/agent_term/commands.lua
+++ b/conf/.config/nvim/lua/agent_term/commands.lua
@@ -1,6 +1,7 @@
 local config = require("agent_term.config")
 local draft = require("agent_term.draft")
 local layouts = require("agent_term.layouts")
+local routing = require("agent_term.routing")
 local state = require("agent_term.state")
 local terminals = require("agent_term.terminals")
 
@@ -39,6 +40,14 @@ local function toggle_draft_buffer()
     return
   end
 
+  -- 現在タブに Agent ドラフトが無い場合は、別タブの Agent ドラフトへ移動する（要望2）。
+  -- Agent タブが見つからなければ、従来どおり現在タブで fallback して開く。
+  if not state.get_draft_bufnr() then
+    if routing.goto_agent_draft() then
+      return
+    end
+  end
+
   local current_bufnr = vim.api.nvim_get_current_buf()
   local focus_opts = {
     draft_height = config.draft.attached_height,
@@ -62,6 +71,7 @@ function M.setup()
   setup_done = true
 
   draft.setup()
+  routing.setup()
 
   vim.api.nvim_create_user_command("AgentCodex", function(command)
     layouts.open_agent_codex({
@@ -194,3 +204,4 @@ function M.setup()
 end
 
 return M
+

--- a/conf/.config/nvim/lua/agent_term/routing.lua
+++ b/conf/.config/nvim/lua/agent_term/routing.lua
@@ -1,0 +1,126 @@
+local state = require("agent_term.state")
+local draft = require("agent_term.draft")
+
+local M = {}
+local setup_done = false
+-- 自動移送中の再入防止フラグ
+local relocating = false
+
+-- 作業タブへ移送する対象（実ファイルを編集する通常バッファ）かどうか。
+-- ターミナル・nofile・名前なしバッファは対象外。
+function M.is_relocatable_file_buf(bufnr)
+  if not state.is_valid_buf(bufnr) then
+    return false
+  end
+  if vim.bo[bufnr].buftype ~= "" then
+    return false
+  end
+  if vim.api.nvim_buf_get_name(bufnr) == "" then
+    return false
+  end
+  return true
+end
+
+-- 作業タブへ移動する。無ければ新規タブを作成して現在タブにする。
+local function goto_or_create_work_tabpage()
+  local work = state.get_work_tabpage()
+  if work then
+    vim.api.nvim_set_current_tabpage(work)
+    return work
+  end
+  vim.cmd("tabnew")
+  return vim.api.nvim_get_current_tabpage()
+end
+
+-- bufnr を作業タブの現在ウィンドウで開く。cursor を渡すと位置を引き継ぐ。
+function M.open_buf_in_work_tab(bufnr, cursor)
+  if not state.is_valid_buf(bufnr) then
+    return false
+  end
+
+  goto_or_create_work_tabpage()
+  pcall(vim.api.nvim_set_current_buf, bufnr)
+  if cursor then
+    pcall(vim.api.nvim_win_set_cursor, 0, cursor)
+  end
+  return true
+end
+
+-- 最近使った Agent タブへ移動し、ドラフト入力をフォーカスする（要望2）。
+-- Agent タブが無ければ false を返す。
+function M.goto_agent_draft()
+  local agent_tab = state.get_agent_tabpage()
+  if not agent_tab then
+    return false
+  end
+
+  vim.api.nvim_set_current_tabpage(agent_tab)
+  return draft.focus_or_open({})
+end
+
+function M.setup()
+  if setup_done then
+    return
+  end
+  setup_done = true
+
+  local group = vim.api.nvim_create_augroup("AgentTermRouting", { clear = true })
+
+  -- タブ離脱時に分類を確定して MRU に記録する。
+  -- 離脱時はタブの構成（ターミナル/ドラフトの有無）が確定しているため正確に分類できる。
+  vim.api.nvim_create_autocmd("TabLeave", {
+    group = group,
+    callback = function()
+      state.record_tabpage(vim.api.nvim_get_current_tabpage())
+    end,
+  })
+
+  -- 起動直後の現在タブも記録しておく。
+  state.record_tabpage(vim.api.nvim_get_current_tabpage())
+
+  -- Agent タブで通常ファイルが開かれたら作業タブへ自動移送する（要望1）。
+  vim.api.nvim_create_autocmd("BufWinEnter", {
+    group = group,
+    callback = function(args)
+      if relocating then
+        return
+      end
+
+      local bufnr = args.buf
+      if not M.is_relocatable_file_buf(bufnr) then
+        return
+      end
+      if not state.is_agent_tabpage(0) then
+        return
+      end
+
+      local win = vim.api.nvim_get_current_win()
+      -- フロートウィンドウ（補完・プレビュー等）は対象外
+      if vim.api.nvim_win_get_config(win).relative ~= "" then
+        return
+      end
+
+      local cursor = vim.api.nvim_win_get_cursor(win)
+      -- このウィンドウに直前まで表示していたバッファ（復帰用）
+      local alt = vim.fn.bufnr("#")
+
+      relocating = true
+      vim.schedule(function()
+        -- Agent タブ側のウィンドウを元のバッファへ戻す
+        if
+          vim.api.nvim_win_is_valid(win)
+          and vim.api.nvim_win_get_buf(win) == bufnr
+          and state.is_valid_buf(alt)
+          and alt ~= bufnr
+        then
+          pcall(vim.api.nvim_win_set_buf, win, alt)
+        end
+
+        M.open_buf_in_work_tab(bufnr, cursor)
+        relocating = false
+      end)
+    end,
+  })
+end
+
+return M

--- a/conf/.config/nvim/lua/agent_term/state.lua
+++ b/conf/.config/nvim/lua/agent_term/state.lua
@@ -4,6 +4,67 @@ function M.is_valid_buf(bufnr)
   return bufnr ~= nil and vim.api.nvim_buf_is_valid(bufnr)
 end
 
+-- タブ単位の MRU 追跡（タブをまたぐためモジュールローカルに保持）
+local mru_work_tabpage = nil
+local mru_agent_tabpage = nil
+
+-- 指定タブが Agent タブ（ドラフト入力またはターミナルを持つ）かどうか。
+-- tabpage 省略時は 0 = 現在タブ。
+function M.is_agent_tabpage(tabpage)
+  tabpage = tabpage or 0
+
+  local ok_input, input_bufnr = pcall(vim.api.nvim_tabpage_get_var, tabpage, "agent_input_bufnr")
+  if ok_input and M.is_valid_buf(input_bufnr) then
+    return true
+  end
+
+  local ok_term, term_bufnr = pcall(vim.api.nvim_tabpage_get_var, tabpage, "agent_terminal_bufnr")
+  if ok_term and M.is_valid_buf(term_bufnr) and vim.bo[term_bufnr].buftype == "terminal" then
+    return true
+  end
+
+  return false
+end
+
+-- タブを Agent / 非Agent に分類して MRU に記録する。
+-- TabLeave 時など、タブの構成が確定した状態で呼ぶこと。
+function M.record_tabpage(tabpage)
+  tabpage = tabpage or vim.api.nvim_get_current_tabpage()
+  if not vim.api.nvim_tabpage_is_valid(tabpage) then
+    return
+  end
+
+  if M.is_agent_tabpage(tabpage) then
+    mru_agent_tabpage = tabpage
+  else
+    mru_work_tabpage = tabpage
+  end
+end
+
+-- 最近使った非Agentタブ（作業タブ）。無効化されていれば nil。
+function M.get_work_tabpage()
+  if
+    mru_work_tabpage
+    and vim.api.nvim_tabpage_is_valid(mru_work_tabpage)
+    and not M.is_agent_tabpage(mru_work_tabpage)
+  then
+    return mru_work_tabpage
+  end
+  return nil
+end
+
+-- 最近使った Agent タブ。無効化されていれば nil。
+function M.get_agent_tabpage()
+  if
+    mru_agent_tabpage
+    and vim.api.nvim_tabpage_is_valid(mru_agent_tabpage)
+    and M.is_agent_tabpage(mru_agent_tabpage)
+  then
+    return mru_agent_tabpage
+  end
+  return nil
+end
+
 function M.get_draft_bufnr()
   if M.is_valid_buf(vim.t.agent_input_bufnr) then
     return vim.t.agent_input_bufnr

--- a/conf/.config/nvim/lua/plugins/git/lazygit.lua
+++ b/conf/.config/nvim/lua/plugins/git/lazygit.lua
@@ -81,8 +81,13 @@ return {
         sync_cwd_from_lazygit()
         -- ウィンドウレイアウトの修復
         vim.schedule(function()
+          -- クリーンアップ・フォーカス処理は現在のタブページ内に限定する。
+          -- nvim_list_wins() は全タブのウィンドウを返すため、これを使うと
+          -- lazygit を Agent タブで閉じた際に別タブへ飛んでしまう。
+          local tabpage = vim.api.nvim_get_current_tabpage()
+
           -- フローティングウィンドウやターミナルバッファをクリーンアップ
-          for _, win in pairs(vim.api.nvim_list_wins()) do
+          for _, win in ipairs(vim.api.nvim_tabpage_list_wins(tabpage)) do
             if vim.api.nvim_win_is_valid(win) then
               local buf = vim.api.nvim_win_get_buf(win)
               local ft = vim.api.nvim_buf_get_option(buf, "filetype")
@@ -90,21 +95,24 @@ return {
 
               -- 不要なバッファタイプを削除
               if ft == "lazygit" or ft == "cmp_menu" or ft == "NvimSeparator" or name == "" then
-                if vim.api.nvim_buf_is_valid(buf) and #vim.api.nvim_list_wins() > 1 then
+                if vim.api.nvim_buf_is_valid(buf) and #vim.api.nvim_tabpage_list_wins(tabpage) > 1 then
                   pcall(vim.api.nvim_win_close, win, true)
                 end
               end
             end
           end
 
-          -- メインエディタウィンドウにフォーカス
-          for _, win in pairs(vim.api.nvim_list_wins()) do
-            if vim.api.nvim_win_is_valid(win) then
-              local buf = vim.api.nvim_win_get_buf(win)
-              local ft = vim.api.nvim_buf_get_option(buf, "filetype")
-              if ft == "lua" or ft == "python" or ft == "javascript" or ft ~= "NvimTree" then
-                vim.api.nvim_set_current_win(win)
-                break
+          -- lazygit.nvim は終了時に起動元ウィンドウへ戻すため、通常はそのままで良い。
+          -- 現在ウィンドウが無効になった場合のみ、同じタブ内のウィンドウへフォーカスする。
+          if not vim.api.nvim_win_is_valid(vim.api.nvim_get_current_win()) then
+            for _, win in ipairs(vim.api.nvim_tabpage_list_wins(tabpage)) do
+              if vim.api.nvim_win_is_valid(win) then
+                local buf = vim.api.nvim_win_get_buf(win)
+                local ft = vim.api.nvim_buf_get_option(buf, "filetype")
+                if ft ~= "NvimTree" then
+                  vim.api.nvim_set_current_win(win)
+                  break
+                end
               end
             end
           end

--- a/conf/.config/nvim/tests/test_agent_term_routing.lua
+++ b/conf/.config/nvim/tests/test_agent_term_routing.lua
@@ -1,0 +1,105 @@
+package.path = vim.fn.getcwd()
+  .. "/conf/.config/nvim/lua/?.lua;"
+  .. vim.fn.getcwd()
+  .. "/conf/.config/nvim/lua/?/init.lua;"
+  .. package.path
+
+local state = require("agent_term.state")
+local routing = require("agent_term.routing")
+local draft = require("agent_term.draft")
+
+local function assert_eq(actual, expected, message)
+  if actual ~= expected then
+    error(string.format("%s: expected %s, got %s", message, tostring(expected), tostring(actual)))
+  end
+end
+
+local function assert_true(value, message)
+  if not value then
+    error(message .. ": expected truthy, got " .. tostring(value))
+  end
+end
+
+-- ヘルパー: Agentタブを1枚作り、ドラフトバッファを表示した状態にする
+local function make_agent_tab()
+  vim.cmd("tabnew")
+  local tabpage = vim.api.nvim_get_current_tabpage()
+  -- 擬似的なターミナル代わりに draft を開く（agent_input_bufnr がセットされる）
+  local draft_bufnr = draft.open_input_buffer({ draft_height = 8 })
+  return tabpage, draft_bufnr
+end
+
+-- 1. is_relocatable_file_buf: 通常ファイルのみ移送対象
+do
+  -- 名前なしバッファ → 対象外
+  vim.cmd("enew")
+  assert_eq(routing.is_relocatable_file_buf(vim.api.nvim_get_current_buf()), false, "noname buf is not relocatable")
+
+  -- 通常ファイル → 対象
+  vim.cmd("edit /tmp/agent_term_routing_dummy.txt")
+  local file_buf = vim.api.nvim_get_current_buf()
+  assert_eq(routing.is_relocatable_file_buf(file_buf), true, "named file buf is relocatable")
+
+  -- nofile バッファ → 対象外
+  local scratch = vim.api.nvim_create_buf(false, true)
+  vim.bo[scratch].buftype = "nofile"
+  assert_eq(routing.is_relocatable_file_buf(scratch), false, "nofile buf is not relocatable")
+end
+
+-- 2. is_agent_tabpage / MRU 記録
+do
+  routing.setup()
+
+  -- 起動直後の最初のタブ（非Agent）
+  local first_tab = vim.api.nvim_list_tabpages()[1]
+  assert_eq(state.is_agent_tabpage(first_tab), false, "plain tab is not agent tab")
+
+  local agent_tab = make_agent_tab()
+  assert_eq(state.is_agent_tabpage(agent_tab), true, "tab with draft buffer is agent tab")
+  assert_eq(state.is_agent_tabpage(first_tab), false, "first tab stays non-agent")
+
+  -- 非Agentタブへ戻る（TabLeave で agent_tab が agent MRU に記録される）
+  vim.api.nvim_set_current_tabpage(first_tab)
+  assert_eq(state.get_agent_tabpage(), agent_tab, "agent MRU recorded on tab leave")
+  assert_eq(state.get_work_tabpage(), first_tab, "work MRU is the current non-agent tab")
+end
+
+-- 3. open_buf_in_work_tab: ファイルを作業タブで開く
+do
+  -- 現在 first_tab(非Agent) に居る前提
+  local work_tab = vim.api.nvim_get_current_tabpage()
+  local file_buf = vim.fn.bufadd("/tmp/agent_term_routing_open.txt")
+  vim.fn.bufload(file_buf)
+
+  -- Agentタブへ移動してから作業タブへ移送されることを確認
+  local agent_tab = state.get_agent_tabpage()
+  vim.api.nvim_set_current_tabpage(agent_tab)
+
+  local ok = routing.open_buf_in_work_tab(file_buf, { 1, 0 })
+  assert_true(ok, "open_buf_in_work_tab succeeds")
+  assert_eq(vim.api.nvim_get_current_tabpage(), work_tab, "moved to work tab")
+  assert_eq(vim.api.nvim_get_current_buf(), file_buf, "file buffer opened in work tab")
+end
+
+-- 4. goto_agent_draft: 別タブから Agent ドラフトへ移動してフォーカス
+do
+  local agent_tab = state.get_agent_tabpage()
+  local draft_bufnr = nil
+  do
+    local ok, _ = pcall(vim.api.nvim_tabpage_get_var, agent_tab, "agent_input_bufnr")
+    if ok then
+      draft_bufnr = vim.api.nvim_tabpage_get_var(agent_tab, "agent_input_bufnr")
+    end
+  end
+
+  -- 作業タブへ移動
+  local work_tab = state.get_work_tabpage()
+  vim.api.nvim_set_current_tabpage(work_tab)
+
+  local ok = routing.goto_agent_draft()
+  assert_true(ok, "goto_agent_draft succeeds")
+  assert_eq(vim.api.nvim_get_current_tabpage(), agent_tab, "switched to agent tab")
+  assert_eq(vim.api.nvim_get_current_buf(), draft_bufnr, "focused agent draft buffer")
+end
+
+print("agent_term routing tests passed")


### PR DESCRIPTION
## 概要

AI Agent用タブ(Neovimのタブページ)と通常編集タブをシームレスに行き来できるようにする。
従来は「タブ切替→ファイルを開く」「タブ切替→`<M-a>`で入力」と2段階の操作が必要だったのを1アクション化する。

## 変更内容

### 要望1: Agentタブで開いた通常ファイルを自動で作業タブへ

- Agentタブで通常ファイル(`gd`/telescope/`:e`/grepジャンプ等)を開くと、自動で作業タブへ移送する
- 移送先は直前にいた非Agentタブ。無ければ新規タブを作成
- Agentタブ側のウィンドウは元のバッファ(ドラフト/ターミナル)へ復帰し、カーソル行も引き継ぐ

### 要望2: `<M-a>` を全タブ対応に拡張

- どのタブからでも `<M-a>` で、現在タブにドラフトが無ければ最近使ったAgentタブ(MRU)へ切り替えて入力にフォーカス
- Agentタブ内では従来どおりトグル(フォーカス/退避)として動作
- Agentタブが1枚も無い場合は従来のfallback(claude/codexターミナルを探して現在タブにドラフト)を維持

### lazygit修正

- 終了時のクリーンアップ・フォーカス処理を現在タブページ内に限定
- 従来は全タブ走査で先頭タブのウィンドウへフォーカスしており、Agentタブでlazygitを閉じると別タブへ飛んでいた

## ファイル

- `lua/agent_term/state.lua` — タブ単位のMRU追跡・Agentタブ判定を追加
- `lua/agent_term/routing.lua`(新規) — タブ分類記録(TabLeave)・自動移送(BufWinEnter)・`goto_agent_draft`
- `lua/agent_term/commands.lua` — `routing.setup()`配線・`<M-a>`拡張
- `lua/plugins/git/lazygit.lua` — 終了時処理を現在タブに限定
- `tests/test_agent_term_routing.lua`(新規) — ルーティングのテスト

## テスト

ヘッドレスnvimはこのセッション(Neovimターミナル内)から実行できないため未実行。レビュー前にローカルで実行をお願いします。

```
nvim --headless --noplugin -u NONE -l conf/.config/nvim/tests/test_agent_term_routing.lua
nvim --headless --noplugin -u NONE -l conf/.config/nvim/tests/test_agent_term_refactor.lua
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
