### PR TITLE
feat: AgentClaudeFork - nvimからClaudeセッションをフォークして新tmuxペインで起動

### DIFF
--- a/conf/.config/nvim/lua/agent_term/commands.lua
+++ b/conf/.config/nvim/lua/agent_term/commands.lua
@@ -147,6 +147,42 @@ function M.setup()
     })
   end, { desc = "Open Claude session picker terminal" })
 
+  vim.api.nvim_create_user_command("AgentClaudeFork", function()
+    local bufnr = vim.api.nvim_get_current_buf()
+    if vim.bo[bufnr].buftype ~= "terminal" then
+      vim.notify("[AgentClaudeFork] Run from a Claude terminal buffer", vim.log.levels.WARN)
+      return
+    end
+
+    local job_pid = vim.b[bufnr].terminal_job_pid
+    if not job_pid then
+      vim.notify("[AgentClaudeFork] No terminal job PID found", vim.log.levels.ERROR)
+      return
+    end
+
+    local session_file = "/tmp/claude-sessions/" .. job_pid
+    local f = io.open(session_file, "r")
+    if not f then
+      vim.notify("[AgentClaudeFork] No session file: " .. session_file, vim.log.levels.ERROR)
+      return
+    end
+    local session_id = f:read("*l")
+    f:close()
+
+    if not session_id or session_id == "" then
+      vim.notify("[AgentClaudeFork] Empty session ID", vim.log.levels.ERROR)
+      return
+    end
+
+    local cwd = vim.fn.getcwd()
+    local cmd = string.format(
+      "tmux split-window -h -c %s \"nvim +'AgentClaude --resume %s --fork-session'\"",
+      vim.fn.shellescape(cwd),
+      session_id
+    )
+    vim.fn.system(cmd)
+  end, { desc = "Fork current Claude session into a new tmux pane with nvim" })
+
   vim.api.nvim_create_user_command("AgentCodexSession", function()
     layouts.open_agent_codex({
       command = "ccsession --codex",

--- a/conf/.config/tmux/scripts/claude-session-cleanup.sh
+++ b/conf/.config/tmux/scripts/claude-session-cleanup.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# SessionEnd hook: remove session ID file
+set -euo pipefail
+
+pid=$PPID
+while [ "$pid" != "1" ]; do
+  cmd=$(ps -p "$pid" -o comm= 2>/dev/null)
+  case "$cmd" in
+    claude|claude.ex|claude.exe)
+      rm -f "/tmp/claude-sessions/$pid"
+      exit 0
+      ;;
+  esac
+  pid=$(ps -p "$pid" -o ppid= 2>/dev/null | tr -d ' ')
+done

--- a/conf/.config/tmux/scripts/claude-session-register.sh
+++ b/conf/.config/tmux/scripts/claude-session-register.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# SessionStart hook: record session ID keyed by claude PID
+set -euo pipefail
+
+mkdir -p /tmp/claude-sessions
+
+pid=$PPID
+while [ "$pid" != "1" ]; do
+  cmd=$(ps -p "$pid" -o comm= 2>/dev/null)
+  case "$cmd" in
+    claude|claude.ex|claude.exe)
+      echo "$CLAUDE_CODE_SESSION_ID" > "/tmp/claude-sessions/$pid"
+      exit 0
+      ;;
+  esac
+  pid=$(ps -p "$pid" -o ppid= 2>/dev/null | tr -d ' ')
+done


### PR DESCRIPTION
## ref

#274

## 背景

- Claude Codeの `/branch`（`--fork-session`）は分岐先に自分が移動するため、元セッションと並行作業できない
- nvimターミナル内のClaudeプロセスのセッションIDは外部から直接取得できない（`CLAUDE_CODE_SESSION_ID` は子プロセスにのみ渡される）

## 目的

nvimのClaudeターミナルバッファから、元セッションを残したまま右tmuxペインにフォークセッションを起動する。

## やったこと

- `AgentClaudeFork` コマンド追加（`agent_term/commands.lua`）
- SessionStartフックでPIDベースのセッションID記録スクリプト追加（`claude-session-register.sh`）
- SessionEndフックでファイル削除スクリプト追加（`claude-session-cleanup.sh`）

## 確認したこと、考えたこと

- セッションID取得方法の検討: `lsof`（一時的にしか開かず不可）、`ls -t`（複数セッション時に曖昧）、tmuxペインオプション（nvim内の複数バッファを区別不可）を検討し、PIDベースのファイル記録を採用
- nvimの `:terminal claude` は claude を直接起動するため `terminal_job_pid` = claude PID が成り立つことを確認
- フックの `$PPID` も同じPIDを指すことを確認済み
- `~/.claude/settings.json` へのフック登録はリポジトリ外のため手動設定が必要
- 詳細: https://github.com/happy663/dotfiles/issues/274

## レビューしてほしいポイント

- キーマップ（例: `<leader>af`）を割り当てるべきか、コマンドのみで十分か
