### PR TITLE
fix: AgentClaudeForkがresume/ccsession経由で動作しない問題を修正

### DIFF
--- a/conf/.claude/settings.base.json
+++ b/conf/.claude/settings.base.json
@@ -110,9 +110,7 @@
       "Bash(which:*)",
       "WebSearch"
     ],
-    "deny": [
-      "Bash(rm:*)"
-    ]
+    "deny": ["Bash(rm:*)"]
   },
   "hooks": {
     "PreToolUse": [
@@ -176,6 +174,10 @@
           {
             "type": "command",
             "command": "bash ~/.config/tmux/scripts/agent-window-status.sh running"
+          },
+          {
+            "type": "command",
+            "command": "bash ~/.config/tmux/scripts/claude-session-register.sh"
           }
         ]
       }

--- a/conf/.config/nvim/lua/agent_term/commands.lua
+++ b/conf/.config/nvim/lua/agent_term/commands.lua
@@ -160,17 +160,49 @@ function M.setup()
       return
     end
 
-    local session_file = "/tmp/claude-sessions/" .. job_pid
-    local f = io.open(session_file, "r")
-    if not f then
-      vim.notify("[AgentClaudeFork] No session file: " .. session_file, vim.log.levels.ERROR)
-      return
+    local function find_session_id(pid)
+      local f = io.open("/tmp/claude-sessions/" .. pid, "r")
+      if f then
+        local id = f:read("*l")
+        f:close()
+        if id and id ~= "" then
+          return id
+        end
+      end
+      local handle = io.popen("ps -eo pid=,ppid=,comm= 2>/dev/null")
+      if not handle then
+        return nil
+      end
+      local children = {}
+      for line in handle:lines() do
+        local cpid, cppid = line:match("^%s*(%d+)%s+(%d+)")
+        if cpid and cppid then
+          children[cppid] = children[cppid] or {}
+          table.insert(children[cppid], cpid)
+        end
+      end
+      handle:close()
+      local queue = children[tostring(pid)] or {}
+      while #queue > 0 do
+        local cpid = table.remove(queue, 1)
+        f = io.open("/tmp/claude-sessions/" .. cpid, "r")
+        if f then
+          local id = f:read("*l")
+          f:close()
+          if id and id ~= "" then
+            return id
+          end
+        end
+        for _, grandchild in ipairs(children[cpid] or {}) do
+          table.insert(queue, grandchild)
+        end
+      end
+      return nil
     end
-    local session_id = f:read("*l")
-    f:close()
 
-    if not session_id or session_id == "" then
-      vim.notify("[AgentClaudeFork] Empty session ID", vim.log.levels.ERROR)
+    local session_id = find_session_id(job_pid)
+    if not session_id then
+      vim.notify("[AgentClaudeFork] No session file found for PID " .. job_pid, vim.log.levels.ERROR)
       return
     end
 


### PR DESCRIPTION
## ref

#274

## 背景

- `AgentClaudeFork` が `AgentClaudeSession`（ccsession）経由でresumeしたセッションで動作しなかった
- 原因: ccsession経由の場合、プロセスツリーが `nvim → ccsession → claude` となり、`terminal_job_pid`（ccsession）と フックが書くPID（claude）が一致しない
- また `SessionStart` フックがresume時に発火しないため、セッションIDファイルが作成されなかった

## やったこと

- `AgentClaudeFork`: `terminal_job_pid` で直接見つからない場合、子プロセスツリーをBFSで辿ってclaude PIDを探すように修正
- `settings.base.json`: `UserPromptSubmit` フックにも `claude-session-register.sh` を追加し、resume時でも最初のプロンプト送信でセッションIDが記録されるようにした

## 確認したこと

- `AgentClaude` 直接起動: `terminal_job_pid` = claude PID → 直接ヒット（従来通り）
- `AgentClaudeSession` 経由: `terminal_job_pid` = ccsession PID → 子プロセス探索でclaude PIDを発見
