### PR TITLE
feat: add AgentClaudeRestart command for TUI display recovery

### DIFF
--- a/conf/.config/nvim/lua/agent_term/commands.lua
+++ b/conf/.config/nvim/lua/agent_term/commands.lua
@@ -23,6 +23,46 @@ local function find_draft_winid()
   return nil
 end
 
+local function find_claude_session_id(pid)
+  local f = io.open("/tmp/claude-sessions/" .. pid, "r")
+  if f then
+    local id = f:read("*l")
+    f:close()
+    if id and id ~= "" then
+      return id
+    end
+  end
+  local handle = io.popen("ps -eo pid=,ppid=,comm= 2>/dev/null")
+  if not handle then
+    return nil
+  end
+  local children = {}
+  for line in handle:lines() do
+    local cpid, cppid = line:match("^%s*(%d+)%s+(%d+)")
+    if cpid and cppid then
+      children[cppid] = children[cppid] or {}
+      table.insert(children[cppid], cpid)
+    end
+  end
+  handle:close()
+  local queue = children[tostring(pid)] or {}
+  while #queue > 0 do
+    local cpid = table.remove(queue, 1)
+    f = io.open("/tmp/claude-sessions/" .. cpid, "r")
+    if f then
+      local id = f:read("*l")
+      f:close()
+      if id and id ~= "" then
+        return id
+      end
+    end
+    for _, grandchild in ipairs(children[cpid] or {}) do
+      table.insert(queue, grandchild)
+    end
+  end
+  return nil
+end
+
 local function toggle_draft_buffer()
   local current_winid = vim.api.nvim_get_current_win()
   local draft_winid = find_draft_winid()
@@ -160,47 +200,7 @@ function M.setup()
       return
     end
 
-    local function find_session_id(pid)
-      local f = io.open("/tmp/claude-sessions/" .. pid, "r")
-      if f then
-        local id = f:read("*l")
-        f:close()
-        if id and id ~= "" then
-          return id
-        end
-      end
-      local handle = io.popen("ps -eo pid=,ppid=,comm= 2>/dev/null")
-      if not handle then
-        return nil
-      end
-      local children = {}
-      for line in handle:lines() do
-        local cpid, cppid = line:match("^%s*(%d+)%s+(%d+)")
-        if cpid and cppid then
-          children[cppid] = children[cppid] or {}
-          table.insert(children[cppid], cpid)
-        end
-      end
-      handle:close()
-      local queue = children[tostring(pid)] or {}
-      while #queue > 0 do
-        local cpid = table.remove(queue, 1)
-        f = io.open("/tmp/claude-sessions/" .. cpid, "r")
-        if f then
-          local id = f:read("*l")
-          f:close()
-          if id and id ~= "" then
-            return id
-          end
-        end
-        for _, grandchild in ipairs(children[cpid] or {}) do
-          table.insert(queue, grandchild)
-        end
-      end
-      return nil
-    end
-
-    local session_id = find_session_id(job_pid)
+    local session_id = find_claude_session_id(job_pid)
     if not session_id then
       vim.notify("[AgentClaudeFork] No session file found for PID " .. job_pid, vim.log.levels.ERROR)
       return
@@ -214,6 +214,40 @@ function M.setup()
     )
     vim.fn.system(cmd)
   end, { desc = "Fork current Claude session into a new tmux pane with nvim" })
+
+  vim.api.nvim_create_user_command("AgentClaudeRestart", function()
+    local bufnr = vim.api.nvim_get_current_buf()
+    if vim.bo[bufnr].buftype ~= "terminal" then
+      vim.notify("[AgentClaudeRestart] Run from a Claude terminal buffer", vim.log.levels.WARN)
+      return
+    end
+
+    local job_pid = vim.b[bufnr].terminal_job_pid
+    if not job_pid then
+      vim.notify("[AgentClaudeRestart] No terminal job PID found", vim.log.levels.ERROR)
+      return
+    end
+
+    local session_id = find_claude_session_id(job_pid)
+    if not session_id then
+      vim.notify("[AgentClaudeRestart] No session file found for PID " .. job_pid, vim.log.levels.ERROR)
+      return
+    end
+
+    local winid = vim.api.nvim_get_current_win()
+    local job_id = vim.b[bufnr].terminal_job_id
+    if job_id then
+      vim.fn.jobstop(job_id)
+    end
+
+    vim.api.nvim_set_current_win(winid)
+    vim.cmd("enew")
+    local resume_cmd = "claude --resume " .. session_id
+    vim.cmd("terminal " .. resume_cmd)
+    local new_bufnr = vim.api.nvim_get_current_buf()
+    state.set_target_terminal_bufnr(new_bufnr)
+    vim.cmd("startinsert")
+  end, { desc = "Restart Claude Code with --resume in the same window" })
 
   vim.api.nvim_create_user_command("AgentCodexSession", function()
     layouts.open_agent_codex({


### PR DESCRIPTION
## ref

#281

## 背景

- Claude Code/CodexをNeovimターミナル(tmux内)で使用中、リサイズ時にTUI表示が崩れて会話が重複表示される
- Inkフレームワークのリドロー機構が原因で、上流(anthropics/claude-code#46834)は未修正
- `"tui": "fullscreen"` で回避可能だが、tmuxスクロールバックが使えなくなるトレードオフがある

## 目的

表示崩れ発生時に、会話コンテキストを維持したままClaude Codeを素早く再起動して表示をリセットする手段を提供する。

## やったこと

- `find_session_id` を `AgentClaudeFork` のローカルスコープからモジュールレベルの `find_claude_session_id` に引き上げ
- `AgentClaudeRestart` コマンドを追加: セッションID取得 → jobstop → 同じウィンドウで `claude --resume` を起動

## 確認したこと、考えたこと

- `AgentClaudeFork` で実績のあるセッションID取得ロジックをそのまま再利用している
- Neovimの `:terminal` は終了後のバッファで再起動できないため、`enew` で新しいバッファを開く方式にした
- `state.set_target_terminal_bufnr` で新バッファをドラフト送信先に更新しているため、AgentDraftSendとの連携は維持される
- 詳細: https://github.com/happy663/dotfiles/issues/281#issuecomment-4826546749

## レビューしてほしいポイント

- jobstop後に即enew + terminalで問題ないか（プロセス終了の待ち合わせが必要なケースはあるか）
- 旧ターミナルバッファの自動削除は不要か（bufhidden=wipeで自動的に消えるか要確認）