### PR TITLE
feat: log-ai-conversationをforkベースのバックグラウンド実行に対応

### DIFF
--- a/conf/.config/ai-agents/skills/log-ai-conversation/SKILL.md
+++ b/conf/.config/ai-agents/skills/log-ai-conversation/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: log-ai-conversation
 description: AIとの会話をまとめてGitHub IssueまたはPull Requestにコメントとして追加する。手動で呼び出して使用。
-allowed-tools: Bash, Read, mcp__acp__Read, WebFetch
+allowed-tools: Bash, Read, Write, mcp__acp__Read, WebFetch
 argument-hint: "[--confirm]"
 disable-model-invocation: false
 ---
@@ -10,14 +10,23 @@ disable-model-invocation: false
 
 現在の会話をまとめて、GitHub IssueまたはPull Requestにコメントとして追加します。
 
-デフォルトは確認なしで即座に投稿します。`--confirm` 引数を付けると、投稿前にユーザー確認を取ります。いずれの場合も、本文を書き出したファイルパスを提示します（Neovimで開いて確認する用途）。
+## 呼び出され方
+
+このスキルは以下のいずれかで呼ばれます:
+
+* 手動で `/log-ai-conversation` を実行（フォアグラウンド実行）
+* `AgentClaudeLogConversation` コマンド経由で fork 先セッション内で実行（バックグラウンド実行）
+
+後者の場合、メインセッションは fork 先を分割ペインで起動した直後に会話を継続できます。fork 先はこのスキルを実行し、完了後も終了せずペインに残ります（ユーザーが確認後に閉じる）。いずれの呼び出しでも、スキル本体の処理は同じです。
 
 ## 対象の会話
 
-* 前回このskillを呼び出した以降の会話を対象にする
-* 初回呼び出しの場合は全会話を対象にする
+* 現在のセッションで交わされた会話を対象にする
+* 「前回どこまで記録したか」は状態として管理しない
+* 代わりに、直前の GitHub コメントを確認し、内容が重複しないようサマリー作成時に判断する
+* セッションを跨いで同じ Issue/PR にログする場合も、直前コメントの確認で重複を回避する
 
-## 出力先の特定
+## 投稿先の特定
 
 1. Octoバッファ（`octo://`で始まるバッファ）が開いている場合
    * バッファの種類（Issue/PR）と番号を文脈から推定する
@@ -32,7 +41,9 @@ disable-model-invocation: false
 * PRにコメントする: 実装済み変更の説明、レビュー対応ログ、CI修正、PRレビューコメントに紐づく会話
 * 迷う場合: コメント投稿前の確認ステップで、Issue/PRどちらに投稿するかを明示してユーザーに確認する
 
-## まとめ方
+## サマリー作成
+
+### まとめ方
 
 * 作業ログ形式（時系列・試行錯誤・主観表現OK）
 * トピックごとに `### {トピック}` で見出しをつける

--- a/conf/.config/nvim/lua/agent_term/commands.lua
+++ b/conf/.config/nvim/lua/agent_term/commands.lua
@@ -216,6 +216,40 @@ function M.setup()
   end, { desc = "Fork current Claude session into a new tmux pane with nvim" })
   vim.keymap.set("n", "<leader>ak", ":AgentClaudeFork<CR>", { desc = "AgentClaudeFork", noremap = true, silent = true })
 
+  vim.api.nvim_create_user_command("AgentClaudeLogConversation", function()
+    local bufnr = vim.api.nvim_get_current_buf()
+    if vim.bo[bufnr].buftype ~= "terminal" then
+      vim.notify("[AgentClaudeLogConversation] Run from a Claude terminal buffer", vim.log.levels.WARN)
+      return
+    end
+
+    local job_pid = vim.b[bufnr].terminal_job_pid
+    if not job_pid then
+      vim.notify("[AgentClaudeLogConversation] No terminal job PID found", vim.log.levels.ERROR)
+      return
+    end
+
+    local session_id = find_claude_session_id(job_pid)
+    if not session_id then
+      vim.notify("[AgentClaudeLogConversation] No session file found for PID " .. job_pid, vim.log.levels.ERROR)
+      return
+    end
+
+    local cwd = vim.fn.getcwd()
+    -- 現在のペインを分割して fork 先 Claude を起動し、/log-ai-conversation を実行させる。
+    -- prompt 引数でスキルを呼ぶだけで、スキル本文が指示として機能する（fork 元の文脈には引きずられない）。
+    -- 完了後の自動終了はしない（ユーザーが確認後にペインを閉じる）。
+    local fork_prompt = "/log-ai-conversation"
+    local inner = string.format("claude --resume %s --fork-session %s", session_id, vim.fn.shellescape(fork_prompt))
+    local cmd = string.format("tmux split-window -h -c %s %s", vim.fn.shellescape(cwd), vim.fn.shellescape(inner))
+    vim.fn.system(cmd)
+    if vim.v.shell_error ~= 0 then
+      vim.notify("[AgentClaudeLogConversation] Failed to open tmux pane", vim.log.levels.ERROR)
+      return
+    end
+    vim.notify("[AgentClaudeLogConversation] Forked log-ai-conversation into a new pane", vim.log.levels.INFO)
+  end, { desc = "Fork Claude session into a split pane and run log-ai-conversation" })
+
   vim.api.nvim_create_user_command("AgentClaudeRestart", function()
     local bufnr = vim.api.nvim_get_current_buf()
     if vim.bo[bufnr].buftype ~= "terminal" then

--- a/conf/.config/nvim/lua/agent_term/commands.lua
+++ b/conf/.config/nvim/lua/agent_term/commands.lua
@@ -63,6 +63,30 @@ local function find_claude_session_id(pid)
   return nil
 end
 
+-- 現在のターミナルバッファからClaudeセッションIDを特定する。
+-- 失敗時は notify して nil を返す。name は通知プレフィックス（コマンド名）。
+local function resolve_claude_session(name)
+  local bufnr = vim.api.nvim_get_current_buf()
+  if vim.bo[bufnr].buftype ~= "terminal" then
+    vim.notify("[" .. name .. "] Run from a Claude terminal buffer", vim.log.levels.WARN)
+    return nil
+  end
+
+  local job_pid = vim.b[bufnr].terminal_job_pid
+  if not job_pid then
+    vim.notify("[" .. name .. "] No terminal job PID found", vim.log.levels.ERROR)
+    return nil
+  end
+
+  local session_id = find_claude_session_id(job_pid)
+  if not session_id then
+    vim.notify("[" .. name .. "] No session file found for PID " .. job_pid, vim.log.levels.ERROR)
+    return nil
+  end
+
+  return session_id
+end
+
 local function toggle_draft_buffer()
   local current_winid = vim.api.nvim_get_current_win()
   local draft_winid = find_draft_winid()
@@ -188,21 +212,8 @@ function M.setup()
   end, { desc = "Open Claude session picker terminal" })
 
   vim.api.nvim_create_user_command("AgentClaudeFork", function()
-    local bufnr = vim.api.nvim_get_current_buf()
-    if vim.bo[bufnr].buftype ~= "terminal" then
-      vim.notify("[AgentClaudeFork] Run from a Claude terminal buffer", vim.log.levels.WARN)
-      return
-    end
-
-    local job_pid = vim.b[bufnr].terminal_job_pid
-    if not job_pid then
-      vim.notify("[AgentClaudeFork] No terminal job PID found", vim.log.levels.ERROR)
-      return
-    end
-
-    local session_id = find_claude_session_id(job_pid)
+    local session_id = resolve_claude_session("AgentClaudeFork")
     if not session_id then
-      vim.notify("[AgentClaudeFork] No session file found for PID " .. job_pid, vim.log.levels.ERROR)
       return
     end
 
@@ -217,21 +228,8 @@ function M.setup()
   vim.keymap.set("n", "<leader>ak", ":AgentClaudeFork<CR>", { desc = "AgentClaudeFork", noremap = true, silent = true })
 
   vim.api.nvim_create_user_command("AgentClaudeLogConversation", function()
-    local bufnr = vim.api.nvim_get_current_buf()
-    if vim.bo[bufnr].buftype ~= "terminal" then
-      vim.notify("[AgentClaudeLogConversation] Run from a Claude terminal buffer", vim.log.levels.WARN)
-      return
-    end
-
-    local job_pid = vim.b[bufnr].terminal_job_pid
-    if not job_pid then
-      vim.notify("[AgentClaudeLogConversation] No terminal job PID found", vim.log.levels.ERROR)
-      return
-    end
-
-    local session_id = find_claude_session_id(job_pid)
+    local session_id = resolve_claude_session("AgentClaudeLogConversation")
     if not session_id then
-      vim.notify("[AgentClaudeLogConversation] No session file found for PID " .. job_pid, vim.log.levels.ERROR)
       return
     end
 
@@ -251,21 +249,8 @@ function M.setup()
   end, { desc = "Fork Claude session into a split pane and run log-ai-conversation" })
 
   vim.api.nvim_create_user_command("AgentClaudeRestart", function()
-    local bufnr = vim.api.nvim_get_current_buf()
-    if vim.bo[bufnr].buftype ~= "terminal" then
-      vim.notify("[AgentClaudeRestart] Run from a Claude terminal buffer", vim.log.levels.WARN)
-      return
-    end
-
-    local job_pid = vim.b[bufnr].terminal_job_pid
-    if not job_pid then
-      vim.notify("[AgentClaudeRestart] No terminal job PID found", vim.log.levels.ERROR)
-      return
-    end
-
-    local session_id = find_claude_session_id(job_pid)
+    local session_id = resolve_claude_session("AgentClaudeRestart")
     if not session_id then
-      vim.notify("[AgentClaudeRestart] No session file found for PID " .. job_pid, vim.log.levels.ERROR)
       return
     end
 

--- a/conf/.config/nvim/lua/plugins/completion/copilot.lua
+++ b/conf/.config/nvim/lua/plugins/completion/copilot.lua
@@ -13,7 +13,20 @@ return {
         vim.g.copilot_nes_debounce = 500
       end,
     },
-    cond = vim.g.not_in_vscode,
+    cond = function()
+      if not vim.g.not_in_vscode then
+        return false
+      end
+
+      local argv = table.concat(vim.v.argv or {}, " ")
+      for _, command in ipairs({ "AgentClaudeSession", "AgentCodex", "Octo" }) do
+        if argv:match("%f[%w]" .. command .. "%f[%W]") then
+          return false
+        end
+      end
+
+      return true
+    end,
     config = function()
       local setup_config = {
         suggestion = {
@@ -97,6 +110,57 @@ return {
         end
       end
 
+      local reset_callbacks = {}
+
+      function _G.reset_copilot(callback)
+        if callback then
+          table.insert(reset_callbacks, callback)
+        end
+
+        if vim.g.copilot_reset_in_progress then
+          return
+        end
+
+        local copilot_client = require("copilot.client")
+        if copilot_client.is_disabled() then
+          local callbacks = reset_callbacks
+          reset_callbacks = {}
+          for _, reset_callback in ipairs(callbacks) do
+            reset_callback()
+          end
+          return
+        end
+
+        vim.g.copilot_reset_in_progress = true
+        _G.toggle_copilot()
+        vim.defer_fn(function()
+          copilot_client.initialized = false
+          _G.toggle_copilot()
+
+          local timer = vim.uv.new_timer()
+          local elapsed = 0
+          local interval = 50
+          local timeout = 5000
+          timer:start(
+            interval,
+            interval,
+            vim.schedule_wrap(function()
+              elapsed = elapsed + interval
+              if copilot_client.initialized or elapsed >= timeout then
+                timer:stop()
+                timer:close()
+                vim.g.copilot_reset_in_progress = false
+                local callbacks = reset_callbacks
+                reset_callbacks = {}
+                for _, reset_callback in ipairs(callbacks) do
+                  reset_callback()
+                end
+              end
+            end)
+          )
+        end, 500)
+      end
+
       -- トグル用のキーマップを設定
       vim.keymap.set("n", "<leader>tc", "<cmd>lua toggle_copilot()<CR>", {
         noremap = true,
@@ -106,4 +170,3 @@ return {
     end,
   },
 }
-

--- a/conf/.config/nvim/lua/plugins/git/diffview.lua
+++ b/conf/.config/nvim/lua/plugins/git/diffview.lua
@@ -45,34 +45,8 @@ return {
           vim.cmd("startinsert")
         end
 
-        -- Copilotのコンテキストリセット
-        -- enable() は同期だがLSP `initialized` ハンドシェイクは非同期に進む。
-        -- 完了を待たずに gitcommit バッファ(nvr経由)が開くと
-        -- ServerNotInitialized エラーが出るため initialized フラグを polling で待つ。
-        local copilot_client_ok, copilot_client = pcall(require, "copilot.client")
-        if _G.toggle_copilot and copilot_client_ok and not copilot_client.is_disabled() then
-          _G.toggle_copilot() -- disable: agent teardown
-          vim.defer_fn(function()
-            copilot_client.initialized = false
-            _G.toggle_copilot() -- enable: agent起動 (非同期init開始)
-
-            local timer = vim.uv.new_timer()
-            local elapsed = 0
-            local interval = 50
-            local timeout = 5000
-            timer:start(
-              interval,
-              interval,
-              vim.schedule_wrap(function()
-                elapsed = elapsed + interval
-                if copilot_client.initialized or elapsed >= timeout then
-                  timer:stop()
-                  timer:close()
-                  start_commit_tab()
-                end
-              end)
-            )
-          end, 100)
+        if _G.reset_copilot then
+          _G.reset_copilot(start_commit_tab)
         else
           start_commit_tab()
         end

--- a/conf/.config/nvim/lua/plugins/git/lazygit.lua
+++ b/conf/.config/nvim/lua/plugins/git/lazygit.lua
@@ -43,11 +43,8 @@ return {
 
       -- Copilotリセット処理を共通化
       local function reset_copilot()
-        if _G.toggle_copilot then
-          _G.toggle_copilot() -- 1回目：無効化
-          vim.defer_fn(function()
-            _G.toggle_copilot() -- 2回目：有効化（コンテキストリセット）
-          end, 500)
+        if _G.reset_copilot then
+          _G.reset_copilot()
         end
       end
 


### PR DESCRIPTION
## ref

#289

## 背景

- log-ai-conversation実行中、スキルが同期的に走るためメイン会話がブロックされる
- ログ記録の完了を待たず、メイン会話を継続したい

## 目的

メイン会話をブロックせず、バックグラウンドでログ記録を実行する

## やったこと

- 新コマンド `AgentClaudeLogConversation` を追加
  - `tmux split-window` で現在のClaudeセッションをforkして起動
  - prompt引数で `/log-ai-conversation` を渡し、fork先でスキルを実行
  - セッションID特定は既存の `find_claude_session_id` を流用
- `SKILL.md` をfork先実行前提に書き直し
  - Agent ツール方式（Phase 1/2A/2S分岐）を削除
  - サマリー作成・投稿手順を1本のフローに統一

## 確認したこと、考えたこと

- 方式比較: 当初Agent ツール方式を実装したが、issueの「agent非依存」方針に合致するfork方式に切り替えた
- fork元の文脈に引きずられる現象: prompt引数でスキルを呼ぶことで、スキル本文が指示として機能し回避できることを確認
- 完了後の自動終了（`/exit` + `kill-session`）はfork先プロセスからでは不安定のため不採用。fork先ペインは完了後も残り、ユーザーが確認後に閉じる
- 動作確認: ユーザー環境で `AgentClaudeLogConversation` を実行し、Issue #289 にコメントが投稿されることを確認済み
- 詳細: https://github.com/happy663/dotfiles/issues/289#issuecomment-4883001526

## レビューしてほしいポイント

- fork先がfork元の文脈に引きずられずスキルを実行できるか（実運用での安定性）
- 完了後のペインが残る仕様でよいか
- Codex版（AgentClaudeFork相当）は未対応・別Issueでよいか
