### PR TITLE
tmuxのウィンドウ名とpane-borderにAgent作業タイトルを表示

### DIFF
--- a/conf/.claude/hooks/claude-pane-task.sh
+++ b/conf/.claude/hooks/claude-pane-task.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Claude Code hook: capture the first user prompt on UserPromptSubmit (submit mode),
+# then generate the tmux pane task title on response completion (stop mode).
+#
+# Split into two phases so the title appears at "response complete" timing (matching
+# Codex), while still reading the clean .prompt field from UserPromptSubmit (avoids
+# transcript parsing noise from command/skill messages).
+#
+# Resume handling: when a title is already cached for the session-id, no LLM call
+# runs; instead the cached title is restored onto the current pane if missing, so
+# resuming the same session in a different pane/window still shows the title.
+#
+# Recursion guard: CLAUDE_TASK_RENAMER breaks re-entry when agent-pane-task.sh
+# calls `claude -p`, which itself triggers UserPromptSubmit/Stop.
+#
+# Usage: claude-pane-task.sh <submit|stop>
+#   submit: save the first prompt to /tmp/claude-prompts/<session_id>
+#   stop:   read the saved prompt and generate the title
+
+set -uo pipefail
+
+MODE="${1:-}"
+
+if [ -n "${CLAUDE_TASK_RENAMER:-}" ]; then
+  exit 0
+fi
+
+if [ -z "${TMUX_PANE:-}" ]; then
+  exit 0
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  exit 0
+fi
+
+INPUT=$(cat)
+SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // empty')
+
+# Stop ペイロードで session_id が取れない場合は transcript_path のファイル名から復元。
+if [ -z "$SESSION_ID" ]; then
+  TRANSCRIPT=$(printf '%s' "$INPUT" | jq -r '.transcript_path // empty')
+  if [ -n "$TRANSCRIPT" ]; then
+    SESSION_ID=$(basename "$TRANSCRIPT" | sed 's/\.jsonl$//')
+  fi
+fi
+
+if [ -z "$SESSION_ID" ]; then
+  exit 0
+fi
+
+TASK_CACHE="/tmp/agent-pane-tasks/$SESSION_ID"
+PROMPT_CACHE_DIR="/tmp/claude-prompts"
+PROMPT_CACHE="$PROMPT_CACHE_DIR/$SESSION_ID"
+
+# キャッシュ済みタイトルを現在のペインに復元する（LLM 呼ばない、差分時のみ更新）。
+restore_pane_task() {
+  local title="$1"
+  [ -z "$title" ] && return
+  local current
+  current=$(tmux display-message -p -t "$TMUX_PANE" "#{@pane-task}" 2>/dev/null)
+  if [ "$current" != "$title" ]; then
+    tmux set-option -pt "$TMUX_PANE" @pane-task "$title" 2>/dev/null
+  fi
+}
+
+# タイトル生成済みのセッション（resume 等）なら、現在のペインに復元して終了。
+if [ -f "$TASK_CACHE" ]; then
+  restore_pane_task "$(cat "$TASK_CACHE" 2>/dev/null)"
+  exit 0
+fi
+
+case "$MODE" in
+  submit)
+    PROMPT=$(printf '%s' "$INPUT" | jq -r '.prompt // empty')
+    [ -z "$PROMPT" ] && exit 0
+    # 初回プロンプト固定: 既存のプロンプトキャッシュがあれば上書きしない。
+    if [ ! -f "$PROMPT_CACHE" ]; then
+      mkdir -p "$PROMPT_CACHE_DIR" 2>/dev/null
+      printf '%s' "$PROMPT" > "$PROMPT_CACHE"
+    fi
+    ;;
+  stop)
+    [ -f "$PROMPT_CACHE" ] || exit 0
+    PROMPT=$(cat "$PROMPT_CACHE")
+    [ -z "$PROMPT" ] && exit 0
+    export CLAUDE_TASK_RENAMER=1
+    SCRIPT="${HOME}/.config/tmux/scripts/agent-pane-task.sh"
+    [ -x "$SCRIPT" ] && "$SCRIPT" "$SESSION_ID" "$PROMPT" claude
+    ;;
+esac

--- a/conf/.claude/settings.base.json
+++ b/conf/.claude/settings.base.json
@@ -110,9 +110,7 @@
       "Bash(which:*)",
       "WebSearch"
     ],
-    "deny": [
-      "Bash(rm:*)"
-    ]
+    "deny": ["Bash(rm:*)"]
   },
   "hooks": {
     "PreToolUse": [
@@ -180,6 +178,10 @@
           {
             "type": "command",
             "command": "bash ~/.config/tmux/scripts/claude-session-register.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash ~/.claude/hooks/claude-pane-task.sh submit"
           }
         ]
       }
@@ -231,6 +233,10 @@
           {
             "type": "command",
             "command": "bash ~/.config/tmux/scripts/agent-window-status.sh done"
+          },
+          {
+            "type": "command",
+            "command": "bash ~/.claude/hooks/claude-pane-task.sh stop"
           }
         ]
       }

--- a/conf/.codex/codex-notify
+++ b/conf/.codex/codex-notify
@@ -2,7 +2,7 @@
 
 "use strict";
 
-const { spawnSync } = require("child_process");
+const { spawn, spawnSync } = require("child_process");
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
@@ -41,11 +41,20 @@ function main() {
     typeof payload?.["last-assistant-message"] === "string"
       ? payload["last-assistant-message"]
       : "";
-  const summary = typeof payload?.summary === "string" ? payload.summary : "";
+  const inputMessages = Array.isArray(payload?.["input-messages"]) ? payload["input-messages"] : [];
+  const summary =
+    inputMessages.find(
+      (m) => typeof m === "string" && m && !m.startsWith("<environment_context>")
+    ) || "";
 
   const title = buildTitle({ cwd, type });
   const message = buildMessage({ lastAssistantMessage, summary, fallback: payloadRaw });
   const group = typeof payload?.["thread-id"] === "string" ? payload["thread-id"] : "";
+
+  // tmux pane task title generation (best-effort, runs detached so it never blocks Codex).
+  if (group) {
+    spawnTitleGeneration(group);
+  }
 
   // `terminal-notifier` には癖があり、特定の先頭文字（例: `(`, `[`, `-`）があると
   // `-title`/`-message` が無視されたり、空になったり、stdin 待ちでハングすることさえあります。
@@ -248,6 +257,70 @@ function parsePositiveInt(value) {
   const parsed = Number.parseInt(value, 10);
   if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
   return parsed;
+}
+
+/**
+ * thread-id に対応する session jsonl を特定し、ユーザーが実際に入力した最初のメッセージ
+ * （environment_context を含まない event_msg の user_message）を返します。
+ *
+ * @param {string} threadId
+ * @returns {string}
+ */
+function readFirstUserMessage(threadId) {
+  try {
+    const sessionsDir = path.join(os.homedir(), ".codex", "sessions");
+    const findResult = spawnSync(
+      "find",
+      [sessionsDir, "-name", `rollout-*-${threadId}.jsonl`, "-print", "-quit"],
+      { encoding: "utf8" }
+    );
+    const jsonlPath = (findResult.stdout || "").trim().split("\n")[0];
+    if (!jsonlPath) return "";
+    const content = fs.readFileSync(jsonlPath, "utf8");
+    for (const line of content.split("\n")) {
+      if (!line.trim()) continue;
+      try {
+        const obj = JSON.parse(line);
+        if (
+          obj.type === "event_msg" &&
+          obj.payload &&
+          obj.payload.type === "user_message" &&
+          typeof obj.payload.message === "string"
+        ) {
+          return obj.payload.message;
+        }
+      } catch {
+        // パース失敗行は無視
+      }
+    }
+  } catch {
+    // ベストエフォート: 例外を投げない
+  }
+  return "";
+}
+
+/**
+ * tmux ペインの作業タイトル生成を非同期（detached）で起動します。
+ * CODEX_TASK_RENAMER 環境変数で再帰を回避しつつ、agent-pane-task.sh に処理を委譲します。
+ *
+ * @param {string} threadId
+ * @returns {void}
+ */
+function spawnTitleGeneration(threadId) {
+  try {
+    if (process.env.CODEX_TASK_RENAMER === "1") return;
+    const message = readFirstUserMessage(threadId);
+    if (!message) return;
+    const script = path.join(os.homedir(), ".config", "tmux", "scripts", "agent-pane-task.sh");
+    const child = spawn(script, [threadId, message, "codex"], {
+      env: { ...process.env, CODEX_TASK_RENAMER: "1" },
+      stdio: "ignore",
+      detached: true,
+    });
+    child.unref();
+  } catch {
+    // ベストエフォート: 決して例外を投げない
+  }
 }
 
 main();

--- a/conf/.config/ai-agents/skills/ai-tmux/scripts/ai-tmux.sh
+++ b/conf/.config/ai-agents/skills/ai-tmux/scripts/ai-tmux.sh
@@ -97,7 +97,7 @@ set_tmux_status() {
   local target="$1"
   local status="$2"
   tmux set-option -w -t "$target" automatic-rename off 2>/dev/null || true
-  tmux set-option -w -t "$target" @agent-status "$status" 2>/dev/null || true
+  tmux set-option -p -t "$target" @agent-status "$status" 2>/dev/null || true
 }
 
 cmd_start() {

--- a/conf/.config/tmux/scripts/agent-pane-task.sh
+++ b/conf/.config/tmux/scripts/agent-pane-task.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# Generate an Agent task title from the first user prompt and set it as a tmux pane option.
+# Usage: agent-pane-task.sh <session_id> <prompt> <agent_kind>
+#   agent_kind: claude | codex   (decides which CLI is used to summarize; codex falls back to claude)
+#
+# Behavior:
+# - Per session-id, the title is generated only once (first prompt). 2nd+ prompts are skipped.
+# - resume keeps the same session-id -> title preserved. fork gets a new session-id -> new title.
+# - Title format: English, lowercase kebab-case, <= 5 words, prefixed with '#' (e.g. #fix-tmux-window-name).
+
+set -uo pipefail
+
+SESSION_ID="${1:-}"
+PROMPT="${2:-}"
+AGENT_KIND="${3:-claude}"
+
+if [ -z "$SESSION_ID" ] || [ -z "$PROMPT" ]; then
+  exit 0
+fi
+
+PANE_ID="${TMUX_PANE:-}"
+if [ -z "$PANE_ID" ]; then
+  exit 0
+fi
+
+CACHE_DIR="/tmp/agent-pane-tasks"
+mkdir -p "$CACHE_DIR" 2>/dev/null
+CACHE_FILE="$CACHE_DIR/$SESSION_ID"
+
+# session-id ごとに1回だけ生成（2回目以降スキップ）。
+# 既存キャッシュがあれば、resume 先ペインへタイトルを復元して終了（LLM 呼ばない）。
+if [ -f "$CACHE_FILE" ]; then
+  CACHED_TITLE=$(cat "$CACHE_FILE" 2>/dev/null)
+  if [ -n "$CACHED_TITLE" ]; then
+    CURRENT=$(tmux display-message -p -t "$PANE_ID" "#{@pane-task}" 2>/dev/null)
+    if [ "$CURRENT" != "$CACHED_TITLE" ]; then
+      tmux set-option -pt "$PANE_ID" @pane-task "$CACHED_TITLE" 2>/dev/null || true
+    fi
+  fi
+  exit 0
+fi
+
+# 並列呼び出しで二重生成しないよう、生成前に空キャッシュを置く。
+: > "$CACHE_FILE"
+
+# Truncate the prompt to keep the LLM input small.
+TRUNCATED=$(printf '%s' "$PROMPT" | head -c 500)
+
+SUMMARY_PROMPT="Summarize the following task into a concise title. Rules: at most 5 words, English, lowercase kebab-case (words joined by single hyphens), no punctuation, no quotes, no explanation, no trailing period. Output ONLY the title on a single line.
+
+---
+$TRUNCATED"
+
+generate_title() {
+  local kind="$1"
+  case "$kind" in
+    codex)
+      if command -v codex >/dev/null 2>&1; then
+        CODEX_TASK_RENAMER=1 codex exec "$SUMMARY_PROMPT" 2>/dev/null || true
+        return
+      fi
+      ;;
+  esac
+  # default / fallback: claude
+  if command -v claude >/dev/null 2>&1; then
+    CLAUDE_TASK_RENAMER=1 claude -p "$SUMMARY_PROMPT" 2>/dev/null || true
+  fi
+}
+
+RAW=$(generate_title "$AGENT_KIND")
+
+# クリーンアップ: 小文字化 → 英数とハイフン以外をハイフンに → トークン化して最初の塊 → 40字制限
+TITLE=$(printf '%s' "$RAW" \
+  | tr '[:upper:]' '[:lower:]' \
+  | tr -c 'a-z0-9\n' '-' \
+  | grep -oE '[a-z0-9][a-z0-9-]*' \
+  | head -1 \
+  | sed 's/--*/-/g; s/^-//; s/-$//' \
+  | cut -c1-40)
+
+if [ -z "$TITLE" ]; then
+  # 生成失敗時は空キャッシュのまま終了（次回もスキップさせ、無駄な再生成を防ぐ）。
+  exit 0
+fi
+
+TITLE="#$TITLE"
+
+# pane option を設定（pane-border / window-status の表示側で参照）。
+tmux set-option -pt "$PANE_ID" @pane-task "$TITLE" 2>/dev/null || true
+
+# キャッシュを確定（resume 時の再生成防止）。
+printf '%s' "$TITLE" > "$CACHE_FILE"

--- a/conf/.config/tmux/scripts/agent-window-status.sh
+++ b/conf/.config/tmux/scripts/agent-window-status.sh
@@ -14,11 +14,11 @@ DIR_NAME=$(basename "$PWD")
 case "$STATUS" in
   running|waiting|done|error)
     tmux set-option -w -t "$PANE_ID" automatic-rename off 2>/dev/null
-    tmux set-option -w -t "$PANE_ID" @agent-status "$STATUS" 2>/dev/null
+    tmux set-option -p -t "$PANE_ID" @agent-status "$STATUS" 2>/dev/null
     tmux rename-window -t "$PANE_ID" "$DIR_NAME"
     ;;
   idle)
-    tmux set-option -wu -t "$PANE_ID" @agent-status 2>/dev/null
+    tmux set-option -pu -t "$PANE_ID" @agent-status 2>/dev/null
     tmux set-option -w -t "$PANE_ID" automatic-rename on 2>/dev/null
     ;;
 esac

--- a/conf/.config/tmux/tmux.conf
+++ b/conf/.config/tmux/tmux.conf
@@ -184,8 +184,8 @@ set -g status-justify left
 set -g status-style "bg=#1a1b26,fg=#c0caf5"
 
 # ウィンドウリスト設定（WezTerm 風パラレログラム: `\` スラント）
-set -g window-status-format "#[fg=#5c6d74,bg=#1a1b26]#[bg=#5c6d74,fg=#c0caf5]   #{?#{==:#{@agent-status},running},#[fg=#9ece6a]● ,#{?#{==:#{@agent-status},waiting},#[fg=#e0af68]◐ ,#{?#{==:#{@agent-status},done},#[fg=#7aa2f7]✓ ,#{?#{==:#{@agent-status},error},#[fg=#f7768e]✕ ,}}}}#[fg=#c0caf5]#W   #[fg=#5c6d74,bg=#1a1b26]"
-set -g window-status-current-format "#[fg=#7aa2f7,bg=#1a1b26]#[bg=#7aa2f7,fg=#1a1b26,bold]   #{?#{==:#{@agent-status},running},#[fg=#9ece6a]● ,#{?#{==:#{@agent-status},waiting},#[fg=#e0af68]◐ ,#{?#{==:#{@agent-status},done},#[fg=#c0caf5]✓ ,#{?#{==:#{@agent-status},error},#[fg=#f7768e]✕ ,}}}}#[fg=#1a1b26]#W   #[fg=#7aa2f7,bg=#1a1b26]"
+set -g window-status-format "#[fg=#5c6d74,bg=#1a1b26]#[bg=#5c6d74,fg=#c0caf5]   #{?#{==:#{@agent-status},running},#[fg=#9ece6a]● ,#{?#{==:#{@agent-status},waiting},#[fg=#e0af68]◐ ,#{?#{==:#{@agent-status},done},#[fg=#7aa2f7]✓ ,#{?#{==:#{@agent-status},error},#[fg=#f7768e]✕ ,}}}}#[fg=#c0caf5]#{?#{@pane-task},#{@pane-task},#W}   #[fg=#5c6d74,bg=#1a1b26]"
+set -g window-status-current-format "#[fg=#7aa2f7,bg=#1a1b26]#[bg=#7aa2f7,fg=#1a1b26,bold]   #{?#{==:#{@agent-status},running},#[fg=#9ece6a]● ,#{?#{==:#{@agent-status},waiting},#[fg=#e0af68]◐ ,#{?#{==:#{@agent-status},done},#[fg=#c0caf5]✓ ,#{?#{==:#{@agent-status},error},#[fg=#f7768e]✕ ,}}}}#[fg=#1a1b26]#{?#{@pane-task},#{@pane-task},#W}   #[fg=#7aa2f7,bg=#1a1b26]"
 set -g window-status-style "fg=#c0caf5"
 set -g window-status-current-style "fg=#1a1b26,bold"
 set -g window-status-separator "  "
@@ -200,7 +200,7 @@ set -g pane-border-lines heavy
 
 # ペインボーダーにアクティブ表示（ペインが2つ以上の時のみ表示）
 set -g pane-border-status off
-set -g pane-border-format ""
+set -g pane-border-format "#[fg=#7aa2f7,bold]#{?#{@pane-task},#{@pane-task},#{b:pane_current_path}}#[default]#{?#{==:#{@agent-status},running}, #[fg=#9ece6a]●,#{?#{==:#{@agent-status},waiting}, #[fg=#e0af68]◐,#{?#{==:#{@agent-status},done}, #[fg=#7aa2f7]✓,#{?#{==:#{@agent-status},error}, #[fg=#f7768e]✕,}}}}"
 set-hook -g after-split-window  'if -F "#{==:#{window_panes},1}" "set -w pane-border-status off" "set -w pane-border-status top"'
 set-hook -g after-kill-pane     'if -F "#{==:#{window_panes},1}" "set -w pane-border-status off" "set -w pane-border-status top"'
 set-hook -g pane-exited         'if -F "#{==:#{window_panes},1}" "set -w pane-border-status off" "set -w pane-border-status top"'


### PR DESCRIPTION
Closes #303

## 概要

tmux のウィンドウ名がディレクトリ名になり、同じプロジェクトの複数ウィンドウで区別がつかない問題を解消します。Agent 起動中のペインに、そのセッションの作業タイトル（最初のユーザープロンプトを LLM で要約した英語 kebab-case）を pane option `@pane-task` として設定し、pane-border とウィンドウ名（ステータスバー）に表示します。

## 変更内容

- 新規 `conf/.config/tmux/scripts/agent-pane-task.sh`: 最初のユーザープロンプトから LLM（claude -p / codex exec）で英語 kebab-case 5語以内のタイトルを生成し、pane option `@pane-task` に設定。session-id 単位で1回のみ生成
- 新規 `conf/.claude/hooks/claude-pane-task.sh`: Claude の UserPromptSubmit で最初のプロンプトを保存、Stop でタイトル生成（応答完了後に統一）。フック再帰は CLAUDE_TASK_RENAMER ガードで回避
- `conf/.codex/codex-notify` 拡張: agent-turn-complete で thread-id から session jsonl の最初の user_message を取得してタイトル生成（detached で非同期）。`summary` 参照の既存バグも修正
- `@agent-status` を window option から pane option に変更（`agent-window-status.sh`, `ai-tmux.sh`）。ケース4（agent||agent）で pane ごとの状態アイコンを実現
- `conf/.config/tmux/tmux.conf`: pane-border-format と window-status-format で `@pane-task` を表示。editor ペイン（Agent 非起動）はディレクトリ名にフォールバック
- タイトルは session-id 単位で固定、resume で別ペインにキャッシュから復元（LLM 呼ばない）

## 検証

- tmux.conf 構文（隔離 server で source-file）、pane option の表示（pane-border / window-status の両方で @pane-task）、editor のディレクトリ名フォールバックを確認
- フックスクリプト単体テスト: submit/stop 動作、初回固定（idempotency）、resume で別ペインへの復元
- 実機テスト: `claude -p` 起動で Stop タイミングに @pane-task が更新されることを確認（`#reply-ok` が生成・設定された）

詳細の設計合意と配慮事項（CLI print mode の再帰回避、Codex notify のペイロード構造、@agent-status の pane option 化の影響など）は issue #303 に記録しています。
